### PR TITLE
fix: 알림 엔티티 팩토리 메서드 제거

### DIFF
--- a/src/main/java/com/benchpress200/photique/notification/domain/entity/Notification.java
+++ b/src/main/java/com/benchpress200/photique/notification/domain/entity/Notification.java
@@ -75,18 +75,6 @@ public class Notification {
         isRead = true;
     }
 
-    public static Notification of(
-            User receiver,
-            NotificationType type,
-            Long targetId
-    ) {
-        return Notification.builder()
-                .receiver(receiver)
-                .type(type)
-                .targetId(targetId)
-                .build();
-    }
-
     public void delete() {
         deletedAt = LocalDateTime.now();
     }


### PR DESCRIPTION
알림 데이터 생성을 비동기 이벤트로 기반으로 카프카 컨슈머에서 별도로 처리합니다.
따라서, 알림 엔티티에 있던 팩토리 메서드를 제거합니다.