### PR TITLE
refactor: 단일작품, 전시회 댓글을 독립된 애그리거트로 취급하도록 아웃박스 팩토리 코드 수정

### DIFF
--- a/src/main/java/com/benchpress200/photique/outbox/application/factory/OutboxEventFactory.java
+++ b/src/main/java/com/benchpress200/photique/outbox/application/factory/OutboxEventFactory.java
@@ -103,16 +103,16 @@ public class OutboxEventFactory {
     }
 
     public OutboxEvent singleWorkCommentCreated(SingleWorkComment singleWorkComment) {
-        // 댓글은 단일작품의 하위 애그리거트로 취급
-        Long singleWorkId = singleWorkComment.getSingleWork().getId();
-        String aggregateId = singleWorkId.toString();
+        Long commentId = singleWorkComment.getId();
+        String aggregateId = commentId.toString();
+
         SingleWorkCommentPayload singleWorkCommentPayload = SingleWorkCommentPayload.from(singleWorkComment);
         JsonNode payload = objectMapper.valueToTree(singleWorkCommentPayload);
 
         return OutboxEvent.builder()
-                .aggregateType(AggregateType.SINGLEWORK)
+                .aggregateType(AggregateType.SINGLEWORK_COMMENT)
                 .aggregateId(aggregateId)
-                .eventType(EventType.COMMENT_CREATED)
+                .eventType(EventType.CREATED)
                 .payload(payload)
                 .build();
     }
@@ -194,16 +194,15 @@ public class OutboxEventFactory {
     }
 
     public OutboxEvent exhibitionCommentCreated(ExhibitionComment exhibitionComment) {
-        // 댓글은 전시회 의 하위 애그리거트로 취급
-        Long exhibitionId = exhibitionComment.getExhibition().getId();
-        String aggregateId = exhibitionId.toString();
+        Long commentId = exhibitionComment.getId();
+        String aggregateId = commentId.toString();
         ExhibitionCommentPayload exhibitionCommentPayload = ExhibitionCommentPayload.from(exhibitionComment);
         JsonNode payload = objectMapper.valueToTree(exhibitionCommentPayload);
 
         return OutboxEvent.builder()
-                .aggregateType(AggregateType.EXHIBITION)
+                .aggregateType(AggregateType.EXHIBITION_COMMENT)
                 .aggregateId(aggregateId)
-                .eventType(EventType.COMMENT_CREATED)
+                .eventType(EventType.CREATED)
                 .payload(payload)
                 .build();
     }

--- a/src/main/java/com/benchpress200/photique/outbox/application/payload/ExhibitionPayload.java
+++ b/src/main/java/com/benchpress200/photique/outbox/application/payload/ExhibitionPayload.java
@@ -64,6 +64,7 @@ public class ExhibitionPayload {
     public static ExhibitionPayload of(Exhibition exhibition) {
         return ExhibitionPayload.builder()
                 .id(exhibition.getId())
+                .writer(Writer.from(exhibition.getWriter()))
                 .likeCount(exhibition.getLikeCount())
                 .build();
     }

--- a/src/main/java/com/benchpress200/photique/outbox/application/payload/SingleWorkPayload.java
+++ b/src/main/java/com/benchpress200/photique/outbox/application/payload/SingleWorkPayload.java
@@ -66,7 +66,9 @@ public class SingleWorkPayload {
     public static SingleWorkPayload of(SingleWork singleWork) {
         return SingleWorkPayload.builder()
                 .id(singleWork.getId())
+                .writer(Writer.from(singleWork.getWriter()))
                 .likeCount(singleWork.getLikeCount())
                 .build();
     }
+
 }

--- a/src/main/java/com/benchpress200/photique/outbox/domain/enumeration/AggregateType.java
+++ b/src/main/java/com/benchpress200/photique/outbox/domain/enumeration/AggregateType.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 @Getter
 public enum AggregateType {
     SINGLEWORK("singlework"),
+    SINGLEWORK_COMMENT("singlework.comment"),
     EXHIBITION("exhibition"),
+    EXHIBITION_COMMENT("exhibition.comment"),
     FOLLOW("follow"),
     USER("user");
 

--- a/src/main/java/com/benchpress200/photique/outbox/domain/enumeration/EventType.java
+++ b/src/main/java/com/benchpress200/photique/outbox/domain/enumeration/EventType.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public enum EventType {
     CREATED("created"),
-    COMMENT_CREATED("commentCreated"),
     UPDATED("updated"),
     LIKED("liked"),
     UNLIKED("unliked"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**버그 수정**
- 댓글 이벤트 추적 시 정확한 식별자 사용으로 개선

**리팩토링**
- 댓글 관련 이벤트 처리 구조 최적화
- 작가 정보가 이벤트 페이로드에 일관되게 포함되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->