### PR TITLE
test: 단일작품 수정 컨트롤러 메서드 테스트 코드 작성

### DIFF
--- a/src/main/java/com/benchpress200/photique/singlework/api/command/request/SingleWorkUpdateRequest.java
+++ b/src/main/java/com/benchpress200/photique/singlework/api/command/request/SingleWorkUpdateRequest.java
@@ -12,11 +12,15 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class SingleWorkUpdateRequest {
     private static final String INVALID_TITLE = "Invalid title";
     private static final String INVALID_DESCRIPTION = "Invalid description";

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
@@ -3,12 +3,15 @@ package com.benchpress200.photique.singlework.api.command.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.common.api.constant.MultipartKey;
 import com.benchpress200.photique.singlework.api.command.request.SingleWorkCreateRequest;
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkUpdateRequest;
 import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCreateRequestFixture;
+import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkUpdateRequestFixture;
 import com.benchpress200.photique.singlework.application.command.port.in.DeleteSingleWorkUseCase;
 import com.benchpress200.photique.singlework.application.command.port.in.PostSingleWorkUseCase;
 import com.benchpress200.photique.singlework.application.command.port.in.UpdateSingleWorkDetailsUseCase;
@@ -449,6 +452,234 @@ public class SingleWorkCommandControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("단일작품 수정 요청 시 요청이 유효하면 204를 반환한다")
+    public void updateSingleWorkDetails_whenRequestIsValid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 수정 요청 시 제목이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidTitleForUpdate")
+    public void updateSingleWorkDetails_whenTitleIsInvalid(String invalidTitle) throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateTitle(true)
+                .title(invalidTitle)
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 수정 요청 시 설명이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidDescriptionForUpdate")
+    public void updateSingleWorkDetails_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateDescription(true)
+                .description(invalidDescription)
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 수정 요청 시 카메라 이름이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidCameraForUpdate")
+    public void updateSingleWorkDetails_whenCameraIsInvalid(String invalidCamera) throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateCamera(true)
+                .camera(invalidCamera)
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 렌즈 이름이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenLensIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateLens(true)
+                .lens("a".repeat(31))
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 조리개 값이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenApertureIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateAperture(true)
+                .aperture("f/123")
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 셔터스피드 값이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenShutterSpeedIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateShutterSpeed(true)
+                .shutterSpeed("-50")
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 ISO 값이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenISOIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateIso(true)
+                .iso("-1000")
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 카테고리 값이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenCategoryIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateCategory(true)
+                .category("두릅비빔")
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 요청 시 장소 이름이 유효하지 않으면 400을 반환한다")
+    public void updateSingleWorkDetails_whenLocationIsInvalid() throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateLocation(true)
+                .location("a".repeat(31))
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 수정 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidTagForUpdate")
+    public void updateSingleWorkDetails_whenTagIsInvalid(List<String> invalidTags) throws Exception {
+        // given
+        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                .updateTags(true)
+                .tags(invalidTags)
+                .build();
+        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<String> invalidTitleForUpdate() {
+        return Stream.of(
+                "",
+                "a".repeat(31)
+        );
+    }
+
+    private static Stream<String> invalidDescriptionForUpdate() {
+        return Stream.of(
+                "",
+                "a".repeat(501)
+        );
+    }
+
+    private static Stream<String> invalidCameraForUpdate() {
+        return Stream.of(
+                "",
+                "a".repeat(31)
+        );
+    }
+
+    private static Stream<List<String>> invalidTagForUpdate() {
+        return Stream.of(
+                List.of("첫번째태그", "두번째태그", "세번째태그", "네번째태그", "다섯번째태그", "여섯번째태그"), // 태그 6개
+                List.of("날아가는 새"), // 공백 포함 태그
+                List.of("아프리카코끼리위에올라탄앵무새") // 11자 이상 태그
+        );
+    }
+
     private static Stream<MockMultipartFile> invalidImage() {
         MockMultipartFile emptyImage = MultipartFileFixture.builder()
                 .key(MultipartKey.IMAGE)
@@ -519,6 +750,14 @@ public class SingleWorkCommandControllerTest extends BaseControllerTest {
                 null,
                 "",
                 "a".repeat(length)  // 31자
+        );
+    }
+
+    private ResultActions requestUpdateSingleWork(Long singleWorkId, Object request) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.SINGLEWORK_DATA, singleWorkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
         );
     }
 

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkUpdateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkUpdateRequestFixture.java
@@ -1,0 +1,186 @@
+package com.benchpress200.photique.singlework.api.command.support.fixture;
+
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkUpdateRequest;
+import java.time.LocalDate;
+import java.util.List;
+
+public class SingleWorkUpdateRequestFixture {
+    private SingleWorkUpdateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private boolean updateTitle = true;
+        private String title = "수정된 제목";
+
+        private boolean updateDescription = false;
+        private String description = null;
+
+        private boolean updateCamera = false;
+        private String camera = null;
+
+        private boolean updateLens = false;
+        private String lens = null;
+
+        private boolean updateAperture = false;
+        private String aperture = null;
+
+        private boolean updateShutterSpeed = false;
+        private String shutterSpeed = null;
+
+        private boolean updateIso = false;
+        private String iso = null;
+
+        private boolean updateCategory = false;
+        private String category = null;
+
+        private boolean updateLocation = false;
+        private String location = null;
+
+        private boolean updateDate = false;
+        private LocalDate date = null;
+
+        private boolean updateTags = false;
+        private List<String> tags = null;
+
+        public Builder updateTitle(boolean updateTitle) {
+            this.updateTitle = updateTitle;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder updateDescription(boolean updateDescription) {
+            this.updateDescription = updateDescription;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder updateCamera(boolean updateCamera) {
+            this.updateCamera = updateCamera;
+            return this;
+        }
+
+        public Builder camera(String camera) {
+            this.camera = camera;
+            return this;
+        }
+
+        public Builder updateLens(boolean updateLens) {
+            this.updateLens = updateLens;
+            return this;
+        }
+
+        public Builder lens(String lens) {
+            this.lens = lens;
+            return this;
+        }
+
+        public Builder updateAperture(boolean updateAperture) {
+            this.updateAperture = updateAperture;
+            return this;
+        }
+
+        public Builder aperture(String aperture) {
+            this.aperture = aperture;
+            return this;
+        }
+
+        public Builder updateShutterSpeed(boolean updateShutterSpeed) {
+            this.updateShutterSpeed = updateShutterSpeed;
+            return this;
+        }
+
+        public Builder shutterSpeed(String shutterSpeed) {
+            this.shutterSpeed = shutterSpeed;
+            return this;
+        }
+
+        public Builder updateIso(boolean updateIso) {
+            this.updateIso = updateIso;
+            return this;
+        }
+
+        public Builder iso(String iso) {
+            this.iso = iso;
+            return this;
+        }
+
+        public Builder updateCategory(boolean updateCategory) {
+            this.updateCategory = updateCategory;
+            return this;
+        }
+
+        public Builder category(String category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder updateLocation(boolean updateLocation) {
+            this.updateLocation = updateLocation;
+            return this;
+        }
+
+        public Builder location(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder updateDate(boolean updateDate) {
+            this.updateDate = updateDate;
+            return this;
+        }
+
+        public Builder date(LocalDate date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder updateTags(boolean updateTags) {
+            this.updateTags = updateTags;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public SingleWorkUpdateRequest build() {
+            return SingleWorkUpdateRequest.builder()
+                    .updateTitle(updateTitle)
+                    .title(title)
+                    .updateDescription(updateDescription)
+                    .description(description)
+                    .updateCamera(updateCamera)
+                    .camera(camera)
+                    .updateLens(updateLens)
+                    .lens(lens)
+                    .updateAperture(updateAperture)
+                    .aperture(aperture)
+                    .updateShutterSpeed(updateShutterSpeed)
+                    .shutterSpeed(shutterSpeed)
+                    .updateIso(updateIso)
+                    .iso(iso)
+                    .updateCategory(updateCategory)
+                    .category(category)
+                    .updateLocation(updateLocation)
+                    .location(location)
+                    .updateDate(updateDate)
+                    .date(date)
+                    .updateTags(updateTags)
+                    .tags(tags)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- SingleWorkUpdateRequest에 @AllArgsConstructor @Builder 추가
- SingleWorkUpdateRequestFixture 생성 (수동 빌더 패턴, 한국어 기본값)
- SingleWorkCommandControllerTest에 updateSingleWorkDetails 테스트 추가
  (성공 케이스 1개, 유효성 검증 실패 케이스 10개)

## 변경 이유
단일작품 수정 API의 요청 유효성 검증에 대한 컨트롤러 테스트 커버리지 확보