### PR TITLE
test: 서비스 클래스의 단일작품 수정 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommandServiceTest.java
@@ -13,6 +13,7 @@ import com.benchpress200.photique.outbox.application.port.out.persistence.Outbox
 import com.benchpress200.photique.outbox.domain.entity.OutboxEvent;
 import com.benchpress200.photique.outbox.domain.support.OutboxEventFixture;
 import com.benchpress200.photique.singlework.application.command.model.SingleWorkCreateCommand;
+import com.benchpress200.photique.singlework.application.command.model.SingleWorkUpdateCommand;
 import com.benchpress200.photique.singlework.application.command.port.out.event.SingleWorkEventPublishPort;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkCommandPort;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkTagCommandPort;
@@ -20,8 +21,11 @@ import com.benchpress200.photique.singlework.application.command.service.SingleW
 import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkQueryPort;
 import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkTagQueryPort;
 import com.benchpress200.photique.singlework.application.support.fixture.SingleWorkCreateCommandFixture;
+import com.benchpress200.photique.singlework.application.support.fixture.SingleWorkUpdateCommandFixture;
 import com.benchpress200.photique.singlework.domain.entity.SingleWork;
 import com.benchpress200.photique.singlework.domain.entity.SingleWorkTag;
+import com.benchpress200.photique.singlework.domain.exception.SingleWorkNotFoundException;
+import com.benchpress200.photique.singlework.domain.exception.SingleWorkNotOwnedException;
 import com.benchpress200.photique.singlework.domain.exception.SingleWorkWriterNotFoundException;
 import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.tag.application.command.port.out.persistence.TagCommandPort;
@@ -136,6 +140,111 @@ public class SingleWorkCommandServiceTest extends BaseServiceTest {
         assertThrows(
                 SingleWorkWriterNotFoundException.class,
                 () -> singleWorkCommandService.postSingleWork(command)
+        );
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 처리에 성공한다")
+    public void updateSingleWorkDetails_WhenCommandIsValid() {
+        //given
+        User writer = UserFixture.builder().build();
+        String imageUrl = "imageUrl";
+        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+        List<SingleWorkTag> singleWorkTags = List.of();
+        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+        doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+        doReturn(singleWorkTags).when(singleWorkTagQueryPort).findBySingleWorkWithTag(any());
+        doReturn(outboxEvent).when(outboxEventFactory).singleWorkUpdated(any(), any());
+        doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+        //when
+        singleWorkCommandService.updateSingleWorkDetails(command);
+
+        //then
+        verify(singleWorkQueryPort).findByIdAndDeletedAtIsNull(command.getSingleWorkId());
+        verify(authenticationUserProviderPort).getCurrentUserId();
+        verify(singleWorkTagQueryPort).findBySingleWorkWithTag(singleWork);
+        verify(outboxEventFactory).singleWorkUpdated(any(), any());
+        verify(outboxEventPort).save(outboxEvent);
+    }
+
+    @Test
+    @DisplayName("태그 업데이트가 포함된 단일작품 수정 처리에 성공한다")
+    public void updateSingleWorkDetails_WhenCommandIncludesTagUpdate() {
+        //given
+        User writer = UserFixture.builder().build();
+        String imageUrl = "imageUrl";
+        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+        List<String> tagNames = List.of("tag1", "tag2");
+        List<Tag> tags = tagNames.stream()
+                .map(Tag::of)
+                .toList();
+        List<SingleWorkTag> singleWorkTags = tags.stream()
+                .map(tag -> SingleWorkTag.of(singleWork, tag))
+                .toList();
+        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder()
+                .updateTags(true)
+                .tags(tagNames)
+                .build();
+        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+        doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+        doNothing().when(singleWorkTagCommandPort).deleteBySingleWork(any());
+        doReturn(tags).when(tagQueryPort).findByNameIn(any());
+        doReturn(tags).when(tagCommandPort).saveAll(any());
+        doReturn(singleWorkTags).when(singleWorkTagCommandPort).saveAll(any());
+        doReturn(singleWorkTags).when(singleWorkTagQueryPort).findBySingleWorkWithTag(any());
+        doReturn(outboxEvent).when(outboxEventFactory).singleWorkUpdated(any(), any());
+        doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+        //when
+        singleWorkCommandService.updateSingleWorkDetails(command);
+
+        //then
+        verify(singleWorkTagCommandPort).deleteBySingleWork(singleWork);
+        verify(singleWorkTagCommandPort).saveAll(any());
+        verify(outboxEventFactory).singleWorkUpdated(any(), any());
+        verify(outboxEventPort).save(outboxEvent);
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 시 작품이 존재하지 않으면 SingleWorkNotFoundException를 던진다")
+    public void updateSingleWorkDetails_WhenSingleWorkNotFound() {
+        //given
+        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+
+        doReturn(Optional.empty()).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+
+        //when & then
+        assertThrows(
+                SingleWorkNotFoundException.class,
+                () -> singleWorkCommandService.updateSingleWorkDetails(command)
+        );
+    }
+
+    @Test
+    @DisplayName("단일작품 수정 시 작품의 소유자가 아니면 SingleWorkNotOwnedException를 던진다")
+    public void updateSingleWorkDetails_WhenNotOwner() {
+        //given
+        User writer = UserFixture.builder().id(1L).build();
+        String imageUrl = "imageUrl";
+        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+
+        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+        doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
+
+        //when & then
+        assertThrows(
+                SingleWorkNotOwnedException.class,
+                () -> singleWorkCommandService.updateSingleWorkDetails(command)
         );
     }
 }

--- a/src/test/java/com/benchpress200/photique/singlework/application/support/fixture/SingleWorkUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/support/fixture/SingleWorkUpdateCommandFixture.java
@@ -1,0 +1,206 @@
+package com.benchpress200.photique.singlework.application.support.fixture;
+
+import com.benchpress200.photique.singlework.application.command.model.SingleWorkUpdateCommand;
+import com.benchpress200.photique.singlework.domain.enumeration.Aperture;
+import com.benchpress200.photique.singlework.domain.enumeration.Category;
+import com.benchpress200.photique.singlework.domain.enumeration.ISO;
+import com.benchpress200.photique.singlework.domain.enumeration.ShutterSpeed;
+import java.time.LocalDate;
+import java.util.List;
+
+public class SingleWorkUpdateCommandFixture {
+    private SingleWorkUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long singleWorkId = 1L;
+
+        private boolean updateTitle = true;
+        private String title = "수정된 제목";
+
+        private boolean updateDescription = false;
+        private String description = "수정된 설명";
+
+        private boolean updateCamera = false;
+        private String camera = "Canon R5";
+
+        private boolean updateLens = false;
+        private String lens = "50mm";
+
+        private boolean updateAperture = false;
+        private Aperture aperture = Aperture.F_1_4;
+
+        private boolean updateShutterSpeed = false;
+        private ShutterSpeed shutterSpeed = ShutterSpeed.S_1_125;
+
+        private boolean updateIso = false;
+        private ISO iso = ISO.ISO_100;
+
+        private boolean updateCategory = false;
+        private Category category = Category.PORTRAIT;
+
+        private boolean updateLocation = false;
+        private String location = "부산";
+
+        private boolean updateDate = false;
+        private LocalDate date = LocalDate.of(2026, 6, 1);
+
+        private boolean updateTags = false;
+        private List<String> tags = List.of("tag1", "tag2");
+
+        private boolean update = true;
+
+        public Builder singleWorkId(Long singleWorkId) {
+            this.singleWorkId = singleWorkId;
+            return this;
+        }
+
+        public Builder updateTitle(boolean updateTitle) {
+            this.updateTitle = updateTitle;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder updateDescription(boolean updateDescription) {
+            this.updateDescription = updateDescription;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder updateCamera(boolean updateCamera) {
+            this.updateCamera = updateCamera;
+            return this;
+        }
+
+        public Builder camera(String camera) {
+            this.camera = camera;
+            return this;
+        }
+
+        public Builder updateLens(boolean updateLens) {
+            this.updateLens = updateLens;
+            return this;
+        }
+
+        public Builder lens(String lens) {
+            this.lens = lens;
+            return this;
+        }
+
+        public Builder updateAperture(boolean updateAperture) {
+            this.updateAperture = updateAperture;
+            return this;
+        }
+
+        public Builder aperture(Aperture aperture) {
+            this.aperture = aperture;
+            return this;
+        }
+
+        public Builder updateShutterSpeed(boolean updateShutterSpeed) {
+            this.updateShutterSpeed = updateShutterSpeed;
+            return this;
+        }
+
+        public Builder shutterSpeed(ShutterSpeed shutterSpeed) {
+            this.shutterSpeed = shutterSpeed;
+            return this;
+        }
+
+        public Builder updateIso(boolean updateIso) {
+            this.updateIso = updateIso;
+            return this;
+        }
+
+        public Builder iso(ISO iso) {
+            this.iso = iso;
+            return this;
+        }
+
+        public Builder updateCategory(boolean updateCategory) {
+            this.updateCategory = updateCategory;
+            return this;
+        }
+
+        public Builder category(Category category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder updateLocation(boolean updateLocation) {
+            this.updateLocation = updateLocation;
+            return this;
+        }
+
+        public Builder location(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder updateDate(boolean updateDate) {
+            this.updateDate = updateDate;
+            return this;
+        }
+
+        public Builder date(LocalDate date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder updateTags(boolean updateTags) {
+            this.updateTags = updateTags;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder update(boolean update) {
+            this.update = update;
+            return this;
+        }
+
+        public SingleWorkUpdateCommand build() {
+            return SingleWorkUpdateCommand.builder()
+                    .singleWorkId(singleWorkId)
+                    .updateTitle(updateTitle)
+                    .title(title)
+                    .updateDescription(updateDescription)
+                    .description(description)
+                    .updateCamera(updateCamera)
+                    .camera(camera)
+                    .updateLens(updateLens)
+                    .lens(lens)
+                    .updateAperture(updateAperture)
+                    .aperture(aperture)
+                    .updateShutterSpeed(updateShutterSpeed)
+                    .shutterSpeed(shutterSpeed)
+                    .updateIso(updateIso)
+                    .iso(iso)
+                    .updateCategory(updateCategory)
+                    .category(category)
+                    .updateLocation(updateLocation)
+                    .location(location)
+                    .updateDate(updateDate)
+                    .date(date)
+                    .updateTags(updateTags)
+                    .tags(tags)
+                    .update(update)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- 서비스 클래스의 단일작품 수정 테스트 코드를 작성했습니다.
- SingleWorkUpdateCommandFixture 픽스처 클래스를 추가했습니다.

## 변경 이유
단일작품 수정 기능의 서비스 레이어 테스트가 없어 기능 안정성을 보장하기 어려웠습니다. 서비스 단위 테스트를 추가하여 안정성을 확보했습니다.