### PR TITLE
test: 단일작품 삭제 컨트롤러 메서드 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
@@ -2,6 +2,7 @@ package com.benchpress200.photique.singlework.api.command.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -750,6 +751,40 @@ public class SingleWorkCommandControllerTest extends BaseControllerTest {
                 null,
                 "",
                 "a".repeat(length)  // 31자
+        );
+    }
+
+    @Test
+    @DisplayName("단일작품 삭제 요청 시 요청이 유효하면 204를 반환한다")
+    public void deleteSingleWork_whenRequestIsValid() throws Exception {
+        // given
+        doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
+
+        // when
+        ResultActions resultActions = requestDeleteSingleWork("1");
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("단일작품 삭제 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
+    public void deleteSingleWork_whenSingleWorkIdIsInvalid() throws Exception {
+        // given
+        doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
+
+        // when
+        ResultActions resultActions = requestDeleteSingleWork("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestDeleteSingleWork(String singleWorkId) throws Exception {
+        return mockMvc.perform(
+                delete(ApiPath.SINGLEWORK_DATA, singleWorkId)
         );
     }
 


### PR DESCRIPTION
## 변경 내용
- SingleWorkCommandController의 deleteSingleWork 메서드에 대한 WebMvcTest를 추가했습니다.
- 유효한 요청 시 204를 반환하는 성공 케이스 테스트를 작성했습니다.
- 작품 ID가 숫자가 아닌 경우 400을 반환하는 실패 케이스 테스트를 작성했습니다.

## 변경 이유
단일작품 삭제 기능의 컨트롤러 레이어 테스트가 없어 기능 안정성을 보장하기 어려웠습니다. 컨트롤러 단위 테스트를 추가하여 안정성을 확보했습니다.

Closes #135