### PR TITLE
test: 단일작품 댓글 생성 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
@@ -1,0 +1,95 @@
+package com.benchpress200.photique.singlework.api.command.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkCommentCreateRequest;
+import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCommentCreateRequestFixture;
+import com.benchpress200.photique.singlework.application.command.port.in.CreateSingleWorkCommentUseCase;
+import com.benchpress200.photique.singlework.application.command.port.in.DeleteSingleWorkCommentUseCase;
+import com.benchpress200.photique.singlework.application.command.port.in.UpdateSingleWorkCommentUseCase;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(
+        controllers = SingleWorkCommentCommandController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("단일작품 댓글 커맨드 컨트롤러 테스트")
+public class SingleWorkCommentCommandControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private CreateSingleWorkCommentUseCase createSingleWorkCommentUseCase;
+
+    @MockitoBean
+    private UpdateSingleWorkCommentUseCase updateSingleWorkCommentUseCase;
+
+    @MockitoBean
+    private DeleteSingleWorkCommentUseCase deleteSingleWorkCommentUseCase;
+
+
+    @Test
+    @DisplayName("단일작품 댓글 생성 요청 시 요청이 유효하면 201을 반환한다")
+    public void createSingleWorkComment_whenRequestIsValid() throws Exception {
+        // given
+        SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder().build();
+        doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
+
+        // when
+        ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isCreated());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 댓글 생성 요청 시 내용이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidContent")
+    public void createSingleWorkComment_whenContentIsInvalid(String invalidContent) throws Exception {
+        // given
+        SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder()
+                .content(invalidContent)
+                .build();
+        doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
+
+        // when
+        ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<String> invalidContent() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(301)
+        );
+    }
+
+    private ResultActions requestCreateSingleWorkComment(Long singleWorkId, Object request) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.SINGLEWORK_COMMENT, singleWorkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkCommentCreateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkCommentCreateRequestFixture.java
@@ -1,0 +1,28 @@
+package com.benchpress200.photique.singlework.api.command.support.fixture;
+
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkCommentCreateRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SingleWorkCommentCreateRequestFixture {
+    private SingleWorkCommentCreateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String content = "기본 댓글 내용";
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public SingleWorkCommentCreateRequest build() {
+            SingleWorkCommentCreateRequest request = new SingleWorkCommentCreateRequest();
+            ReflectionTestUtils.setField(request, "content", content);
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkCommentCommandControllerTest` 추가: 댓글 생성 성공(201) 및 content 유효성 실패(400) 케이스 테스트
- `SingleWorkCommentCreateRequestFixture` 추가: 테스트용 요청 객체 빌더 픽스처

## 변경 이유
단일작품 댓글 생성 API(`createSingleWorkComment`)의 요청/응답 스펙 및 유효성 검증 로직을 컨트롤러 레벨에서 검증하기 위해 WebMvcTest 기반 테스트를 추가하였습니다.

Closes #139