### PR TITLE
test: 단일작품 댓글 수정 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
@@ -2,12 +2,15 @@ package com.benchpress200.photique.singlework.api.command.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.singlework.api.command.request.SingleWorkCommentCreateRequest;
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkCommentUpdateRequest;
 import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCommentCreateRequestFixture;
+import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCommentUpdateRequestFixture;
 import com.benchpress200.photique.singlework.application.command.port.in.CreateSingleWorkCommentUseCase;
 import com.benchpress200.photique.singlework.application.command.port.in.DeleteSingleWorkCommentUseCase;
 import com.benchpress200.photique.singlework.application.command.port.in.UpdateSingleWorkCommentUseCase;
@@ -77,7 +80,48 @@ public class SingleWorkCommentCommandControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("단일작품 댓글 수정 요청 시 요청이 유효하면 204를 반환한다")
+    public void updateSingleWorkComment_whenRequestIsValid() throws Exception {
+        // given
+        SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder().build();
+        doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @ParameterizedTest
+    @DisplayName("단일작품 댓글 수정 요청 시 내용이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidContentForUpdate")
+    public void updateSingleWorkComment_whenContentIsInvalid(String invalidContent) throws Exception {
+        // given
+        SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder()
+                .content(invalidContent)
+                .build();
+        doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
+
+        // when
+        ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
     private static Stream<String> invalidContent() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(301)
+        );
+    }
+
+    private static Stream<String> invalidContentForUpdate() {
         return Stream.of(
                 null,
                 "",
@@ -88,6 +132,14 @@ public class SingleWorkCommentCommandControllerTest extends BaseControllerTest {
     private ResultActions requestCreateSingleWorkComment(Long singleWorkId, Object request) throws Exception {
         return mockMvc.perform(
                 post(ApiPath.SINGLEWORK_COMMENT, singleWorkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    private ResultActions requestUpdateSingleWorkComment(Long commentId, Object request) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.SINGLEWORK_COMMENT_DATA, commentId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkCommentUpdateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/support/fixture/SingleWorkCommentUpdateRequestFixture.java
@@ -1,0 +1,28 @@
+package com.benchpress200.photique.singlework.api.command.support.fixture;
+
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkCommentUpdateRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SingleWorkCommentUpdateRequestFixture {
+    private SingleWorkCommentUpdateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String content = "수정된 댓글 내용";
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public SingleWorkCommentUpdateRequest build() {
+            SingleWorkCommentUpdateRequest request = new SingleWorkCommentUpdateRequest();
+            ReflectionTestUtils.setField(request, "content", content);
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkCommentCommandControllerTest`에 `updateSingleWorkComment` 성공(204) 및 content 유효성 실패(400) 케이스 테스트 추가
- `SingleWorkCommentUpdateRequestFixture` 추가: 테스트용 수정 요청 객체 빌더 픽스처

## 변경 이유
단일작품 댓글 수정 API(`updateSingleWorkComment`)의 요청/응답 스펙 및 유효성 검증 로직을 컨트롤러 레벨에서 검증하기 위해 WebMvcTest 기반 테스트를 추가하였습니다.

Closes #140