### PR TITLE
단일작품 좋아요 추가 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkLikeCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkLikeCommandControllerTest.java
@@ -1,0 +1,84 @@
+package com.benchpress200.photique.singlework.api.command.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.singlework.application.command.port.in.AddSingleWorkLikeUseCase;
+import com.benchpress200.photique.singlework.application.command.port.in.CancelSingleWorkLikeUseCase;
+import com.benchpress200.photique.singlework.domain.exception.SingleWorkAlreadyLikedException;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(
+        controllers = SingleWorkLikeCommandController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("단일작품 좋아요 커맨드 컨트롤러 테스트")
+public class SingleWorkLikeCommandControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private AddSingleWorkLikeUseCase addSingleWorkLikeUseCase;
+
+    @MockitoBean
+    private CancelSingleWorkLikeUseCase cancelSingleWorkLikeUseCase;
+
+    @Test
+    @DisplayName("단일작품 좋아요 추가 요청 시 요청이 유효하면 201을 반환한다")
+    public void addSingleWorkLike_whenRequestIsValid() throws Exception {
+        // given
+        doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+
+        // when
+        ResultActions resultActions = requestAddSingleWorkLike("1");
+
+        // then
+        resultActions
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("단일작품 좋아요 추가 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
+    public void addSingleWorkLike_whenSingleWorkIdIsNotNumber() throws Exception {
+        // given
+        doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+
+        // when
+        ResultActions resultActions = requestAddSingleWorkLike("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 좋아요 추가 요청 시 이미 좋아요를 눌렀으면 409를 반환한다")
+    public void addSingleWorkLike_whenAlreadyLiked() throws Exception {
+        // given
+        doThrow(new SingleWorkAlreadyLikedException(1L, 1L))
+                .when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+
+        // when
+        ResultActions resultActions = requestAddSingleWorkLike("1");
+
+        // then
+        resultActions
+                .andExpect(status().isConflict());
+    }
+
+    private ResultActions requestAddSingleWorkLike(String singleWorkId) throws Exception {
+        return mockMvc.perform(post(ApiPath.SINGLEWORK_LIKE, singleWorkId));
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkLikeCommandControllerTest` 신규 추가
- 정상 요청(201), 숫자가 아닌 PathVariable(400), 중복 좋아요(409) 총 3개 케이스 검증

## 변경 이유
`SingleWorkLikeCommandController.addSingleWorkLike()`에 대한 WebMvcTest 기반 컨트롤러 테스트가 없어 작성하였습니다.

Closes #147