### PR TITLE
test: 단일작품 상세조회 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkQueryControllerTest.java
@@ -1,0 +1,77 @@
+package com.benchpress200.photique.singlework.api.query.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.singlework.api.query.support.fixture.SingleWorkDetailsResultFixture;
+import com.benchpress200.photique.singlework.application.query.port.in.GetSingleWorkDetailsUseCase;
+import com.benchpress200.photique.singlework.application.query.port.in.SearchMySingleWorkUseCase;
+import com.benchpress200.photique.singlework.application.query.port.in.SearchSingleWorkUseCase;
+import com.benchpress200.photique.singlework.application.query.result.SingleWorkDetailsResult;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(
+        controllers = SingleWorkQueryController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("단일작품 쿼리 컨트롤러 테스트")
+public class SingleWorkQueryControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private GetSingleWorkDetailsUseCase getSingleWorkDetailsUseCase;
+
+    @MockitoBean
+    private SearchSingleWorkUseCase searchSingleWorkUseCase;
+
+    @MockitoBean
+    private SearchMySingleWorkUseCase searchMySingleWorkUseCase;
+
+    @Test
+    @DisplayName("단일작품 상세조회 요청 시 요청이 유효하면 200을 반환한다")
+    public void getSingleWorkDetails_whenRequestIsValid() throws Exception {
+        // given
+        SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkDetails("1");
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("단일작품 상세조회 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
+    public void getSingleWorkDetails_whenSingleWorkIdIsInvalid() throws Exception {
+        // given
+        SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkDetails("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestGetSingleWorkDetails(String singleWorkId) throws Exception {
+        return mockMvc.perform(
+                get(ApiPath.SINGLEWORK_DATA, singleWorkId)
+        );
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/api/query/support/fixture/SingleWorkDetailsResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/support/fixture/SingleWorkDetailsResultFixture.java
@@ -1,0 +1,158 @@
+package com.benchpress200.photique.singlework.api.query.support.fixture;
+
+import com.benchpress200.photique.singlework.application.query.result.SingleWorkDetailsResult;
+import com.benchpress200.photique.singlework.application.query.result.Writer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SingleWorkDetailsResultFixture {
+
+    private SingleWorkDetailsResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id = 1L;
+        private Writer writer = Writer.of(1L, "작성자닉네임", "https://example.com/profile.jpg");
+        private String title = "기본 제목";
+        private String description = "기본 설명";
+        private String image = "https://example.com/image.jpg";
+        private String camera = "기본 카메라";
+        private String lens = "기본 렌즈";
+        private String aperture = "f/1.8";
+        private String shutterSpeed = "1/100";
+        private String iso = "ISO 100";
+        private String category = "풍경";
+        private String location = "서울";
+        private LocalDate date = LocalDate.of(2024, 1, 1);
+        private List<String> tags = List.of("태그1", "태그2");
+        private Long likeCount = 10L;
+        private Long viewCount = 100L;
+        private LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 0, 0);
+        private boolean isLiked = false;
+        private boolean isFollowing = false;
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder writer(Writer writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder image(String image) {
+            this.image = image;
+            return this;
+        }
+
+        public Builder camera(String camera) {
+            this.camera = camera;
+            return this;
+        }
+
+        public Builder lens(String lens) {
+            this.lens = lens;
+            return this;
+        }
+
+        public Builder aperture(String aperture) {
+            this.aperture = aperture;
+            return this;
+        }
+
+        public Builder shutterSpeed(String shutterSpeed) {
+            this.shutterSpeed = shutterSpeed;
+            return this;
+        }
+
+        public Builder iso(String iso) {
+            this.iso = iso;
+            return this;
+        }
+
+        public Builder category(String category) {
+            this.category = category;
+            return this;
+        }
+
+        public Builder location(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder date(LocalDate date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder likeCount(Long likeCount) {
+            this.likeCount = likeCount;
+            return this;
+        }
+
+        public Builder viewCount(Long viewCount) {
+            this.viewCount = viewCount;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder isLiked(boolean isLiked) {
+            this.isLiked = isLiked;
+            return this;
+        }
+
+        public Builder isFollowing(boolean isFollowing) {
+            this.isFollowing = isFollowing;
+            return this;
+        }
+
+        public SingleWorkDetailsResult build() {
+            return SingleWorkDetailsResult.builder()
+                    .id(id)
+                    .writer(writer)
+                    .title(title)
+                    .description(description)
+                    .image(image)
+                    .camera(camera)
+                    .lens(lens)
+                    .aperture(aperture)
+                    .shutterSpeed(shutterSpeed)
+                    .iso(iso)
+                    .category(category)
+                    .location(location)
+                    .date(date)
+                    .tags(tags)
+                    .likeCount(likeCount)
+                    .viewCount(viewCount)
+                    .createdAt(createdAt)
+                    .isLiked(isLiked)
+                    .isFollowing(isFollowing)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkQueryControllerTest` 추가: 단일작품 상세조회 API에 대한 WebMvcTest 작성
- `SingleWorkDetailsResultFixture` 추가: 테스트용 결과 픽스처 빌더 작성

## 변경 이유
단일작품 상세조회 API(`getSingleWorkDetails`)의 요청/응답 스펙 및 예외 처리를 컨트롤러 레벨에서 검증하기 위해 테스트 코드를 추가하였습니다.

Closes #151