### PR TITLE
test: 좋아요한 단일작품 검색 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkLikeQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkLikeQueryControllerTest.java
@@ -1,0 +1,126 @@
+package com.benchpress200.photique.singlework.api.query.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.singlework.application.query.port.in.SearchLikedSingleWorkUseCase;
+import com.benchpress200.photique.singlework.application.query.result.LikedSingleWorkSearchResult;
+import com.benchpress200.photique.singlework.application.query.support.fixture.LikedSingleWorkSearchResultFixture;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebMvcTest(
+        controllers = SingleWorkLikeQueryController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("단일작품 좋아요 쿼리 컨트롤러 테스트")
+public class SingleWorkLikeQueryControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private SearchLikedSingleWorkUseCase searchLikedSingleWorkUseCase;
+
+    @Test
+    @DisplayName("좋아요한 단일작품 검색 요청 시 요청이 유효하면 200을 반환한다")
+    public void searchLikedSingleWork_whenRequestIsValid() throws Exception {
+        // given
+        LikedSingleWorkSearchResult result = LikedSingleWorkSearchResultFixture.builder().build();
+        doReturn(result).when(searchLikedSingleWorkUseCase).searchLikedSingleWork(any());
+
+        // when
+        ResultActions resultActions = requestSearchLikedSingleWork(null, 0, 10);
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @DisplayName("좋아요한 단일작품 검색 요청 시 키워드가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidKeywords")
+    public void searchLikedSingleWork_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = requestSearchLikedSingleWork(invalidKeyword, 0, 10);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("좋아요한 단일작품 검색 요청 시 페이지 번호가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidPages")
+    public void searchLikedSingleWork_whenPageIsInvalid(Integer invalidPage) throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = requestSearchLikedSingleWork(null, invalidPage, 10);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("좋아요한 단일작품 검색 요청 시 페이지 크기가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidSizes")
+    public void searchLikedSingleWork_whenSizeIsInvalid(Integer invalidSize) throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = requestSearchLikedSingleWork(null, 0, invalidSize);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<String> invalidKeywords() {
+        return Stream.of(
+                "a",             // 1자 - 최소 길이 미만
+                "a".repeat(101)  // 101자 - 최대 길이 초과
+        );
+    }
+
+    private static Stream<Integer> invalidPages() {
+        return Stream.of(-1);
+    }
+
+    private static Stream<Integer> invalidSizes() {
+        return Stream.of(
+                0,  // 최솟값 미만
+                51  // 최댓값 초과
+        );
+    }
+
+    private ResultActions requestSearchLikedSingleWork(String keyword, Integer page, Integer size) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_MY_LIKE);
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/LikedSingleWorkSearchResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/LikedSingleWorkSearchResultFixture.java
@@ -1,0 +1,59 @@
+package com.benchpress200.photique.singlework.application.query.support.fixture;
+
+import com.benchpress200.photique.singlework.application.query.result.LikedSingleWorkSearchResult;
+import java.util.List;
+
+public class LikedSingleWorkSearchResultFixture {
+
+    private LikedSingleWorkSearchResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int page = 0;
+        private int size = 10;
+        private long totalElements = 0;
+        private int totalPages = 0;
+        private boolean isFirst = true;
+        private boolean isLast = true;
+        private boolean hasNext = false;
+        private boolean hasPrevious = false;
+
+        public Builder page(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder totalElements(long totalElements) {
+            this.totalElements = totalElements;
+            return this;
+        }
+
+        public Builder totalPages(int totalPages) {
+            this.totalPages = totalPages;
+            return this;
+        }
+
+        public LikedSingleWorkSearchResult build() {
+            return LikedSingleWorkSearchResult.builder()
+                    .page(page)
+                    .size(size)
+                    .totalElements(totalElements)
+                    .totalPages(totalPages)
+                    .isFirst(isFirst)
+                    .isLast(isLast)
+                    .hasNext(hasNext)
+                    .hasPrevious(hasPrevious)
+                    .singleWorks(List.of())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkLikeQueryController.searchLikedSingleWork()` WebMvcTest 컨트롤러 테스트를 추가하였습니다.
- 테스트에서 사용하는 `LikedSingleWorkSearchResultFixture`를 추가하였습니다.
- 검증 케이스: 유효한 요청(200), 키워드 길이 위반(400), 페이지 음수(400), 페이지 크기 범위 초과(400)

## 변경 이유
`GET /api/v1/singleworks/likes/me` API의 요청/응답 스펙과 유효성 검증 동작을 컨트롤러 레벨에서 보장하기 위해 테스트를 작성하였습니다.

Closes #155