### PR TITLE
test: getSingleWorkComments 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkCommentQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkCommentQueryControllerTest.java
@@ -1,0 +1,105 @@
+package com.benchpress200.photique.singlework.api.query.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.singlework.application.query.port.in.GetSingleWorkCommentsUseCase;
+import com.benchpress200.photique.singlework.application.query.result.SingleWorkCommentsResult;
+import com.benchpress200.photique.singlework.application.query.support.fixture.SingleWorkCommentsResultFixture;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@WebMvcTest(
+        controllers = SingleWorkCommentQueryController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("단일작품 댓글 쿼리 컨트롤러 테스트")
+public class SingleWorkCommentQueryControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private GetSingleWorkCommentsUseCase getSingleWorkCommentsUseCase;
+
+    @Test
+    @DisplayName("단일작품 댓글 목록 조회 요청 시 요청이 유효하면 200을 반환한다")
+    public void getSingleWorkComments_whenRequestIsValid() throws Exception {
+        // given
+        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkComments("1", 0, 5);
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("단일작품 댓글 목록 조회 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
+    public void getSingleWorkComments_whenSingleWorkIdIsInvalid() throws Exception {
+        // given
+        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkComments("invalid", 0, 5);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일작품 댓글 목록 조회 요청 시 페이지가 음수이면 400을 반환한다")
+    public void getSingleWorkComments_whenPageIsNegative() throws Exception {
+        // given
+        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkComments("1", -1, 5);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 11})
+    @DisplayName("단일작품 댓글 목록 조회 요청 시 사이즈가 유효하지 않으면 400을 반환한다")
+    public void getSingleWorkComments_whenSizeIsInvalid(int invalidSize) throws Exception {
+        // given
+        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+
+        // when
+        ResultActions resultActions = requestGetSingleWorkComments("1", 0, invalidSize);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestGetSingleWorkComments(
+            String singleWorkId, Integer page, Integer size) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_COMMENT, singleWorkId);
+        if (page != null) builder = builder.param("page", String.valueOf(page));
+        if (size != null) builder = builder.param("size", String.valueOf(size));
+        return mockMvc.perform(builder);
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/SingleWorkCommentsResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/SingleWorkCommentsResultFixture.java
@@ -1,0 +1,59 @@
+package com.benchpress200.photique.singlework.application.query.support.fixture;
+
+import com.benchpress200.photique.singlework.application.query.result.SingleWorkCommentsResult;
+import java.util.List;
+
+public class SingleWorkCommentsResultFixture {
+
+    private SingleWorkCommentsResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int page = 0;
+        private int size = 10;
+        private long totalElements = 0;
+        private int totalPages = 0;
+        private boolean isFirst = true;
+        private boolean isLast = true;
+        private boolean hasNext = false;
+        private boolean hasPrevious = false;
+
+        public Builder page(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder totalElements(long totalElements) {
+            this.totalElements = totalElements;
+            return this;
+        }
+
+        public Builder totalPages(int totalPages) {
+            this.totalPages = totalPages;
+            return this;
+        }
+
+        public SingleWorkCommentsResult build() {
+            return SingleWorkCommentsResult.builder()
+                    .page(page)
+                    .size(size)
+                    .totalElements(totalElements)
+                    .totalPages(totalPages)
+                    .isFirst(isFirst)
+                    .isLast(isLast)
+                    .hasNext(hasNext)
+                    .hasPrevious(hasPrevious)
+                    .comments(List.of())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `SingleWorkCommentQueryControllerTest` 추가 — 유효한 요청 시 200, 잘못된 singleWorkId 시 400, 음수 page 시 400, 범위 초과 size(0, 11) 시 400 검증 테스트 5개 작성
- `SingleWorkCommentsResultFixture` 추가 — 빌더 패턴 기반 테스트용 결과 픽스처

## 변경 이유
`SingleWorkCommentQueryController.getSingleWorkComments()`에 대한 WebMvcTest 기반 컨트롤러 테스트가 없어 요청 파라미터 유효성 검증 및 정상 흐름을 테스트하기 위해 추가하였습니다.

Closes #154