### PR TITLE
전시회 수정 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
@@ -3,14 +3,18 @@ package com.benchpress200.photique.exhibition.api.command.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.common.api.constant.MultipartKey;
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCreateRequest;
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionWorkCreateRequest;
+import com.benchpress200.photique.exhibition.api.command.request.ExhibitionWorkUpdateRequest;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCreateRequestFixture;
+import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionUpdateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionWorkCreateRequestFixture;
+import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionWorkUpdateRequestFixture;
 import com.benchpress200.photique.exhibition.application.command.port.in.DeleteExhibitionUseCase;
 import com.benchpress200.photique.exhibition.application.command.port.in.OpenExhibitionUseCase;
 import com.benchpress200.photique.exhibition.application.command.port.in.UpdateExhibitionDetailsUseCase;
@@ -18,6 +22,7 @@ import com.benchpress200.photique.support.base.BaseControllerTest;
 import com.benchpress200.photique.support.fixture.MultipartFileFixture;
 import com.benchpress200.photique.support.fixture.MultipartJsonFixture;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -439,6 +444,235 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("전시회 수정 요청 시 요청이 유효하면 204를 반환한다")
+    public void updateExhibitionDetails_whenRequestIsValid() throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 제목이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidTitlesForUpdate")
+    public void updateExhibitionDetails_whenTitleIsInvalid(String invalidTitle) throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateTitle(true)
+                .title(invalidTitle)
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 설명이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidDescriptionsForUpdate")
+    public void updateExhibitionDetails_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateDescription(true)
+                .description(invalidDescription)
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 카드 색상이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidCardColorsForUpdate")
+    public void updateExhibitionDetails_whenCardColorIsInvalid(String invalidCardColor) throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateCardColor(true)
+                .cardColor(invalidCardColor)
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidTagsForUpdate")
+    public void updateExhibitionDetails_whenTagsIsInvalid(List<String> invalidTags) throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateTags(true)
+                .tags(invalidTags)
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전시회 수정 요청 시 작품 목록이 null이면 400을 반환한다")
+    public void updateExhibitionDetails_whenWorksIsNull() throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(null)
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전시회 수정 요청 시 작품 목록이 비어있으면 400을 반환한다")
+    public void updateExhibitionDetails_whenWorksIsEmpty() throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(List.of())
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전시회 수정 요청 시 작품 ID가 null이면 400을 반환한다")
+    public void updateExhibitionDetails_whenWorkIdIsNull() throws Exception {
+        // given
+        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                .id(null)
+                .build();
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(List.of(work))
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 작품 순서가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidDisplayOrdersForUpdate")
+    public void updateExhibitionDetails_whenWorkDisplayOrderIsInvalid(Integer invalidDisplayOrder) throws Exception {
+        // given
+        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                .displayOrder(invalidDisplayOrder)
+                .build();
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(List.of(work))
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 작품 제목이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidWorkTitlesForUpdate")
+    public void updateExhibitionDetails_whenWorkTitleIsInvalid(String invalidWorkTitle) throws Exception {
+        // given
+        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                .title(invalidWorkTitle)
+                .build();
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(List.of(work))
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 수정 요청 시 작품 설명이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidWorkDescriptionsForUpdate")
+    public void updateExhibitionDetails_whenWorkDescriptionIsInvalid(String invalidWorkDescription) throws Exception {
+        // given
+        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                .description(invalidWorkDescription)
+                .build();
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                .updateWorks(true)
+                .works(List.of(work))
+                .build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전시회 수정 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
+    public void updateExhibitionDetails_whenExhibitionIdIsNotNumber() throws Exception {
+        // given
+        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
+        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionDetails("invalid", request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
     private static Stream<String> invalidTitles() {
         return Stream.of(
                 null,
@@ -530,6 +764,61 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
         );
     }
 
+    private static Stream<String> invalidTitlesForUpdate() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(31)
+        );
+    }
+
+    private static Stream<String> invalidDescriptionsForUpdate() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(501)
+        );
+    }
+
+    private static Stream<String> invalidCardColorsForUpdate() {
+        return Stream.of(
+                null,
+                "a".repeat(21)
+        );
+    }
+
+    private static Stream<List<String>> invalidTagsForUpdate() {
+        return Stream.of(
+                List.of("태그1", "태그2", "태그3", "태그4", "태그5", "태그6"), // 태그 6개
+                List.of("공백 태그"), // 공백 포함 태그
+                List.of("아프리카코끼리위에올라탄앵무새") // 10자 초과 태그
+        );
+    }
+
+    private static Stream<Integer> invalidDisplayOrdersForUpdate() {
+        return Stream.of(
+                null,
+                -1,
+                10
+        );
+    }
+
+    private static Stream<String> invalidWorkTitlesForUpdate() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(31)
+        );
+    }
+
+    private static Stream<String> invalidWorkDescriptionsForUpdate() {
+        return Stream.of(
+                null,
+                "",
+                "a".repeat(201)
+        );
+    }
+
     private ResultActions requestOpenExhibition(
             MockMultipartFile exhibitionPart,
             MockMultipartFile imagePart
@@ -539,6 +828,28 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
                         .file(exhibitionPart)
                         .file(imagePart)
                         .contentType(MediaType.MULTIPART_FORM_DATA)
+        );
+    }
+
+    private ResultActions requestUpdateExhibitionDetails(
+            Long exhibitionId,
+            Object request
+    ) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.EXHIBITION_DATA, exhibitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    private ResultActions requestUpdateExhibitionDetails(
+            String exhibitionId,
+            Object request
+    ) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.EXHIBITION_DATA, exhibitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
         );
     }
 }

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionUpdateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionUpdateRequestFixture.java
@@ -1,0 +1,93 @@
+package com.benchpress200.photique.exhibition.api.command.support.fixture;
+
+import com.benchpress200.photique.exhibition.api.command.request.ExhibitionWorkUpdateRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ExhibitionUpdateRequestFixture {
+    private ExhibitionUpdateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private boolean updateTitle = true;
+        private String title = "수정된 전시회 제목";
+        private boolean updateDescription = false;
+        private String description = null;
+        private boolean updateCardColor = false;
+        private String cardColor = null;
+        private boolean updateTags = false;
+        private List<String> tags = null;
+        private boolean updateWorks = false;
+        private List<ExhibitionWorkUpdateRequest> works = null;
+
+        public Builder updateTitle(boolean updateTitle) {
+            this.updateTitle = updateTitle;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder updateDescription(boolean updateDescription) {
+            this.updateDescription = updateDescription;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder updateCardColor(boolean updateCardColor) {
+            this.updateCardColor = updateCardColor;
+            return this;
+        }
+
+        public Builder cardColor(String cardColor) {
+            this.cardColor = cardColor;
+            return this;
+        }
+
+        public Builder updateTags(boolean updateTags) {
+            this.updateTags = updateTags;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder updateWorks(boolean updateWorks) {
+            this.updateWorks = updateWorks;
+            return this;
+        }
+
+        public Builder works(List<ExhibitionWorkUpdateRequest> works) {
+            this.works = works;
+            return this;
+        }
+
+        public Map<String, Object> build() {
+            Map<String, Object> map = new HashMap<>();
+            map.put("updateTitle", updateTitle);
+            map.put("title", title);
+            map.put("updateDescription", updateDescription);
+            map.put("description", description);
+            map.put("updateCardColor", updateCardColor);
+            map.put("cardColor", cardColor);
+            map.put("updateTags", updateTags);
+            map.put("tags", tags);
+            map.put("updateWorks", updateWorks);
+            map.put("works", works);
+            return map;
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionWorkUpdateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionWorkUpdateRequestFixture.java
@@ -1,0 +1,48 @@
+package com.benchpress200.photique.exhibition.api.command.support.fixture;
+
+import com.benchpress200.photique.exhibition.api.command.request.ExhibitionWorkUpdateRequest;
+
+public class ExhibitionWorkUpdateRequestFixture {
+    private ExhibitionWorkUpdateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id = 1L;
+        private Integer displayOrder = 0;
+        private String title = "수정된 작품 제목";
+        private String description = "수정된 작품 설명";
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder displayOrder(Integer displayOrder) {
+            this.displayOrder = displayOrder;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public ExhibitionWorkUpdateRequest build() {
+            ExhibitionWorkUpdateRequest request = new ExhibitionWorkUpdateRequest();
+            request.setId(id);
+            request.setDisplayOrder(displayOrder);
+            request.setTitle(title);
+            request.setDescription(description);
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `ExhibitionCommandControllerTest`에 `updateExhibitionDetails` 테스트 25개 추가
- `ExhibitionUpdateRequestFixture` 픽스처 작성
- `ExhibitionWorkUpdateRequestFixture` 픽스처 작성

## 변경 이유
전시회 수정 API(`updateExhibitionDetails`)의 요청/응답 스펙 및 유효성 검증 로직을 컨트롤러 레벨에서 검증하기 위해 WebMvcTest 기반 테스트를 추가하였습니다.

Closes #164