### PR TITLE
전시회 삭제 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
@@ -2,6 +2,7 @@ package com.benchpress200.photique.exhibition.api.command.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -850,6 +851,40 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
                 patch(ApiPath.EXHIBITION_DATA, exhibitionId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    @Test
+    @DisplayName("전시회 삭제 요청 시 요청이 유효하면 204를 반환한다")
+    public void deleteExhibition_whenRequestIsValid() throws Exception {
+        // given
+        doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
+
+        // when
+        ResultActions resultActions = requestDeleteExhibition("1");
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("전시회 삭제 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
+    public void deleteExhibition_whenExhibitionIdIsNotNumber() throws Exception {
+        // given
+        doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
+
+        // when
+        ResultActions resultActions = requestDeleteExhibition("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestDeleteExhibition(String exhibitionId) throws Exception {
+        return mockMvc.perform(
+                delete(ApiPath.EXHIBITION_DATA, exhibitionId)
         );
     }
 }


### PR DESCRIPTION
## 변경 내용
- `ExhibitionCommandControllerTest`에 `deleteExhibition` 테스트 2개 추가
- 유효한 요청 시 204 반환 검증
- 전시회 ID가 숫자가 아닐 때 400 반환 검증

## 변경 이유
전시회 삭제 API(`deleteExhibition`)의 응답 스펙 및 경로 변수 유효성을 컨트롤러 레벨에서 검증하기 위해 WebMvcTest 기반 테스트를 추가하였습니다.

Closes #165