### PR TITLE
test: 전시회 감상평 수정 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
@@ -2,12 +2,15 @@ package com.benchpress200.photique.exhibition.api.command.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCommentCreateRequest;
+import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCommentUpdateRequest;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCommentCreateRequestFixture;
+import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCommentUpdateRequestFixture;
 import com.benchpress200.photique.exhibition.application.command.port.in.CreateExhibitionCommentUseCase;
 import com.benchpress200.photique.exhibition.application.command.port.in.DeleteExhibitionCommentUseCase;
 import com.benchpress200.photique.exhibition.application.command.port.in.UpdateExhibitionCommentUseCase;
@@ -91,6 +94,59 @@ public class ExhibitionCommentCommandControllerTest extends BaseControllerTest {
     ) throws Exception {
         return mockMvc.perform(
                 post(ApiPath.EXHIBITION_COMMENT, exhibitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    @Test
+    @DisplayName("전시회 감상평 수정 요청 시 요청이 유효하면 204를 반환한다")
+    public void updateExhibitionComment_whenRequestIsValid() throws Exception {
+        // given
+        ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder().build();
+        doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 감상평 수정 요청 시 내용이 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidContentsForUpdate")
+    public void updateExhibitionComment_whenContentIsInvalid(String invalidContent) throws Exception {
+        // given
+        ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder()
+                .content(invalidContent)
+                .build();
+        doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
+
+        // when
+        ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<String> invalidContentsForUpdate() {
+        return Stream.of(
+                null,
+                "",
+                " ",
+                "a".repeat(301)
+        );
+    }
+
+    private ResultActions requestUpdateExhibitionComment(
+            Long commentId,
+            Object request
+    ) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.EXHIBITION_COMMENT_DATA, commentId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionCommentUpdateRequestFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/support/fixture/ExhibitionCommentUpdateRequestFixture.java
@@ -1,0 +1,28 @@
+package com.benchpress200.photique.exhibition.api.command.support.fixture;
+
+import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCommentUpdateRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ExhibitionCommentUpdateRequestFixture {
+    private ExhibitionCommentUpdateRequestFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String content = "기본 감상평";
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public ExhibitionCommentUpdateRequest build() {
+            ExhibitionCommentUpdateRequest request = new ExhibitionCommentUpdateRequest();
+            ReflectionTestUtils.setField(request, "content", content);
+            return request;
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- `ExhibitionCommentUpdateRequestFixture` 픽스처 클래스 신규 생성
- `ExhibitionCommentCommandControllerTest`에 수정 API 테스트 메서드 추가
  - `updateExhibitionComment_whenRequestIsValid()` — 204 응답 검증
  - `updateExhibitionComment_whenContentIsInvalid()` — 유효하지 않은 content에 대해 400 응답 검증 (null, 빈 문자열, 공백, 301자 초과)

## 변경 이유
`PATCH /api/v1/exhibitions/comments/{commentId}` 엔드포인트의 입력값 검증 및 정상 응답을 컨트롤러 계층에서 보장하기 위해 테스트 코드를 작성하였습니다.

Closes #167