### PR TITLE
test: 전시회 감상평 삭제 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
@@ -2,6 +2,7 @@ package com.benchpress200.photique.exhibition.api.command.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,6 +150,40 @@ public class ExhibitionCommentCommandControllerTest extends BaseControllerTest {
                 patch(ApiPath.EXHIBITION_COMMENT_DATA, commentId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    @Test
+    @DisplayName("전시회 감상평 삭제 요청 시 요청이 유효하면 204를 반환한다")
+    public void deleteExhibitionComment_whenRequestIsValid() throws Exception {
+        // given
+        doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
+
+        // when
+        ResultActions resultActions = requestDeleteExhibitionComment("1");
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("전시회 감상평 삭제 요청 시 감상평 ID가 숫자가 아니면 400을 반환한다")
+    public void deleteExhibitionComment_whenCommentIdIsNotNumber() throws Exception {
+        // given
+        doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
+
+        // when
+        ResultActions resultActions = requestDeleteExhibitionComment("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestDeleteExhibitionComment(String commentId) throws Exception {
+        return mockMvc.perform(
+                delete(ApiPath.EXHIBITION_COMMENT_DATA, commentId)
         );
     }
 }


### PR DESCRIPTION
## 변경 내용
- 전시회 감상평 삭제 요청 시 요청이 유효하면 204를 반환하는 테스트 추가
- 전시회 감상평 삭제 요청 시 감상평 ID가 숫자가 아니면 400을 반환하는 테스트 추가
- `requestDeleteExhibitionComment(String)` 헬퍼 메서드 추가

## 변경 이유
전시회 감상평 삭제 API의 컨트롤러 레이어에 대한 테스트 코드가 없어, 유효한 요청 및 잘못된 경로 변수 입력에 대한 검증을 추가하였습니다.

Closes #168