### PR TITLE
test: 전시회 상세조회 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
@@ -1,0 +1,77 @@
+package com.benchpress200.photique.exhibition.api.query.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.exhibition.application.query.port.in.GetExhibitionDetailsUseCase;
+import com.benchpress200.photique.exhibition.application.query.port.in.SearchExhibitionUseCase;
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionDetailsResult;
+import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionDetailsResultFixture;
+import com.benchpress200.photique.singlework.application.query.port.in.SearchMyExhibitionUseCase;
+import com.benchpress200.photique.support.base.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(
+        controllers = ExhibitionQueryController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class
+        }
+)
+@DisplayName("전시회 쿼리 컨트롤러 테스트")
+public class ExhibitionQueryControllerTest extends BaseControllerTest {
+
+    @MockitoBean
+    private GetExhibitionDetailsUseCase getExhibitionDetailsUseCase;
+
+    @MockitoBean
+    private SearchExhibitionUseCase searchExhibitionUseCase;
+
+    @MockitoBean
+    private SearchMyExhibitionUseCase searchMyExhibitionUseCase;
+
+    @Test
+    @DisplayName("전시회 상세조회 요청 시 요청이 유효하면 200을 반환한다")
+    public void getExhibitionDetails_whenRequestIsValid() throws Exception {
+        // given
+        ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
+        doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
+
+        // when
+        ResultActions resultActions = requestGetExhibitionDetails("1");
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("전시회 상세조회 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
+    public void getExhibitionDetails_whenExhibitionIdIsNotNumber() throws Exception {
+        // given
+        ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
+        doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
+
+        // when
+        ResultActions resultActions = requestGetExhibitionDetails("invalid");
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions requestGetExhibitionDetails(String exhibitionId) throws Exception {
+        return mockMvc.perform(
+                get(ApiPath.EXHIBITION_DATA, exhibitionId)
+        );
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionDetailsResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionDetailsResultFixture.java
@@ -1,0 +1,108 @@
+package com.benchpress200.photique.exhibition.application.query.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionDetailsResult;
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionWorkResult;
+import com.benchpress200.photique.exhibition.application.query.result.Writer;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExhibitionDetailsResultFixture {
+    private ExhibitionDetailsResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id = 1L;
+        private Writer writer = Writer.of(1L, "작성자닉네임", "https://example.com/profile.jpg");
+        private String title = "기본 전시회 제목";
+        private String description = "기본 전시회 설명";
+        private List<String> tags = List.of("태그1", "태그2");
+        private List<ExhibitionWorkResult> works = List.of();
+        private Long viewCount = 0L;
+        private Long likeCount = 0L;
+        private LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+        private boolean isFollowing = false;
+        private boolean isLiked = false;
+        private boolean isBookmarked = false;
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder writer(Writer writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder works(List<ExhibitionWorkResult> works) {
+            this.works = works;
+            return this;
+        }
+
+        public Builder viewCount(Long viewCount) {
+            this.viewCount = viewCount;
+            return this;
+        }
+
+        public Builder likeCount(Long likeCount) {
+            this.likeCount = likeCount;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder isFollowing(boolean isFollowing) {
+            this.isFollowing = isFollowing;
+            return this;
+        }
+
+        public Builder isLiked(boolean isLiked) {
+            this.isLiked = isLiked;
+            return this;
+        }
+
+        public Builder isBookmarked(boolean isBookmarked) {
+            this.isBookmarked = isBookmarked;
+            return this;
+        }
+
+        public ExhibitionDetailsResult build() {
+            return ExhibitionDetailsResult.builder()
+                    .id(id)
+                    .writer(writer)
+                    .title(title)
+                    .description(description)
+                    .tags(tags)
+                    .works(works)
+                    .viewCount(viewCount)
+                    .likeCount(likeCount)
+                    .createdAt(createdAt)
+                    .isFollowing(isFollowing)
+                    .isLiked(isLiked)
+                    .isBookmarked(isBookmarked)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- ExhibitionQueryControllerTest 추가 (getExhibitionDetails 테스트)
  - 유효한 전시회 ID 요청 시 200 반환 검증
  - 숫자가 아닌 전시회 ID 요청 시 400 반환 검증
- ExhibitionDetailsResultFixture 추가 (ExhibitionDetailsResult 픽스처)

## 변경 이유
전시회 상세조회 API(ExhibitionQueryController.getExhibitionDetails())에 대한
컨트롤러 레벨 테스트가 없어 요청/응답 스펙 및 예외 처리를 검증하기 위해 추가하였습니다.

Closes #173