### PR TITLE
test: 전시회 검색 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
@@ -9,16 +9,22 @@ import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.application.query.port.in.GetExhibitionDetailsUseCase;
 import com.benchpress200.photique.exhibition.application.query.port.in.SearchExhibitionUseCase;
 import com.benchpress200.photique.exhibition.application.query.result.ExhibitionDetailsResult;
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionSearchResult;
 import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionDetailsResultFixture;
+import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionSearchResultFixture;
 import com.benchpress200.photique.singlework.application.query.port.in.SearchMyExhibitionUseCase;
 import com.benchpress200.photique.support.base.BaseControllerTest;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @WebMvcTest(
         controllers = ExhibitionQueryController.class,
@@ -69,9 +75,124 @@ public class ExhibitionQueryControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
+    public void searchExhibition_whenRequestIsValid() throws Exception {
+        // given
+        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchExhibition(
+                get(ApiPath.EXHIBITION_ROOT)
+                        .param("target", "work")
+                        .param("keyword", "기본키워드")
+                        .param("page", "0")
+                        .param("size", "10")
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("전시회 검색 요청 시 target이 유효하지 않으면 400을 반환한다")
+    public void searchExhibition_whenTargetIsInvalid() throws Exception {
+        // given
+        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchExhibition(
+                get(ApiPath.EXHIBITION_ROOT)
+                        .param("target", "invalid")
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidKeywords")
+    public void searchExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
+        // given
+        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchExhibition(
+                get(ApiPath.EXHIBITION_ROOT)
+                        .param("keyword", invalidKeyword)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전시회 검색 요청 시 page가 음수이면 400을 반환한다")
+    public void searchExhibition_whenPageIsNegative() throws Exception {
+        // given
+        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchExhibition(
+                get(ApiPath.EXHIBITION_ROOT)
+                        .param("page", "-1")
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidSizes")
+    public void searchExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
+        // given
+        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchExhibition(
+                get(ApiPath.EXHIBITION_ROOT)
+                        .param("size", invalidSize)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    private static Stream<String> invalidKeywords() {
+        return Stream.of(
+                "한",                       // 1자 (최솟값 미만)
+                "a".repeat(101)             // 101자 (최댓값 초과)
+        );
+    }
+
+    private static Stream<String> invalidSizes() {
+        return Stream.of(
+                "0",    // 최솟값 미만
+                "51"    // 최댓값 초과
+        );
+    }
+
     private ResultActions requestGetExhibitionDetails(String exhibitionId) throws Exception {
         return mockMvc.perform(
                 get(ApiPath.EXHIBITION_DATA, exhibitionId)
         );
+    }
+
+    private ResultActions requestSearchExhibition(
+            MockHttpServletRequestBuilder requestBuilder
+    ) throws Exception {
+        return mockMvc.perform(requestBuilder);
     }
 }

--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionSearchResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionSearchResultFixture.java
@@ -1,0 +1,79 @@
+package com.benchpress200.photique.exhibition.application.query.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionSearchResult;
+import java.util.List;
+
+public class ExhibitionSearchResultFixture {
+    private ExhibitionSearchResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int page = 0;
+        private int size = 30;
+        private long totalElements = 0L;
+        private int totalPages = 0;
+        private boolean isFirst = true;
+        private boolean isLast = true;
+        private boolean hasNext = false;
+        private boolean hasPrevious = false;
+        private List<com.benchpress200.photique.exhibition.application.query.result.SearchedExhibition> exhibitions = List.of();
+
+        public Builder page(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder totalElements(long totalElements) {
+            this.totalElements = totalElements;
+            return this;
+        }
+
+        public Builder totalPages(int totalPages) {
+            this.totalPages = totalPages;
+            return this;
+        }
+
+        public Builder isFirst(boolean isFirst) {
+            this.isFirst = isFirst;
+            return this;
+        }
+
+        public Builder isLast(boolean isLast) {
+            this.isLast = isLast;
+            return this;
+        }
+
+        public Builder hasNext(boolean hasNext) {
+            this.hasNext = hasNext;
+            return this;
+        }
+
+        public Builder hasPrevious(boolean hasPrevious) {
+            this.hasPrevious = hasPrevious;
+            return this;
+        }
+
+        public ExhibitionSearchResult build() {
+            return ExhibitionSearchResult.builder()
+                    .page(page)
+                    .size(size)
+                    .totalElements(totalElements)
+                    .totalPages(totalPages)
+                    .isFirst(isFirst)
+                    .isLast(isLast)
+                    .hasNext(hasNext)
+                    .hasPrevious(hasPrevious)
+                    .exhibitions(exhibitions)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- ExhibitionQueryControllerTest에 searchExhibition 테스트 케이스 추가
  - 유효한 요청 시 200 반환 검증
  - 유효하지 않은 target 시 400 반환 검증
  - 유효하지 않은 keyword(1자/101자) 시 400 반환 검증
  - 음수 page 시 400 반환 검증
  - 유효하지 않은 size(0/51) 시 400 반환 검증
- ExhibitionSearchResultFixture 추가 (ExhibitionSearchResult 픽스처)

## 변경 이유
전시회 검색 API(ExhibitionQueryController.searchExhibition())에 대한
컨트롤러 레벨 테스트가 없어 요청 유효성 검증 및 응답 스펙을 확인하기 위해 추가하였습니다.

Closes #174