### PR TITLE
test: 내 전시회 검색 API 컨트롤러 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
@@ -13,6 +13,8 @@ import com.benchpress200.photique.exhibition.application.query.result.Exhibition
 import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionDetailsResultFixture;
 import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionSearchResultFixture;
 import com.benchpress200.photique.singlework.application.query.port.in.SearchMyExhibitionUseCase;
+import com.benchpress200.photique.singlework.application.query.result.MyExhibitionSearchResult;
+import com.benchpress200.photique.singlework.application.query.support.fixture.MyExhibitionSearchResultFixture;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -170,6 +172,82 @@ public class ExhibitionQueryControllerTest extends BaseControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @DisplayName("내 전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
+    public void searchMyExhibition_whenRequestIsValid() throws Exception {
+        // given
+        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchMyExhibition(
+                get(ApiPath.EXHIBITION_MY_DATA)
+                        .param("keyword", "기본키워드")
+                        .param("page", "0")
+                        .param("size", "10")
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest
+    @DisplayName("내 전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidKeywords")
+    public void searchMyExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
+        // given
+        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchMyExhibition(
+                get(ApiPath.EXHIBITION_MY_DATA)
+                        .param("keyword", invalidKeyword)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내 전시회 검색 요청 시 page가 음수이면 400을 반환한다")
+    public void searchMyExhibition_whenPageIsNegative() throws Exception {
+        // given
+        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchMyExhibition(
+                get(ApiPath.EXHIBITION_MY_DATA)
+                        .param("page", "-1")
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @DisplayName("내 전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
+    @MethodSource("invalidSizes")
+    public void searchMyExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
+        // given
+        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
+
+        // when
+        ResultActions resultActions = requestSearchMyExhibition(
+                get(ApiPath.EXHIBITION_MY_DATA)
+                        .param("size", invalidSize)
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+
     private static Stream<String> invalidKeywords() {
         return Stream.of(
                 "한",                       // 1자 (최솟값 미만)
@@ -191,6 +269,12 @@ public class ExhibitionQueryControllerTest extends BaseControllerTest {
     }
 
     private ResultActions requestSearchExhibition(
+            MockHttpServletRequestBuilder requestBuilder
+    ) throws Exception {
+        return mockMvc.perform(requestBuilder);
+    }
+
+    private ResultActions requestSearchMyExhibition(
             MockHttpServletRequestBuilder requestBuilder
     ) throws Exception {
         return mockMvc.perform(requestBuilder);

--- a/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/MyExhibitionSearchResultFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/MyExhibitionSearchResultFixture.java
@@ -1,0 +1,80 @@
+package com.benchpress200.photique.singlework.application.query.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.query.result.SearchedExhibition;
+import com.benchpress200.photique.singlework.application.query.result.MyExhibitionSearchResult;
+import java.util.List;
+
+public class MyExhibitionSearchResultFixture {
+    private MyExhibitionSearchResultFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int page = 0;
+        private int size = 30;
+        private long totalElements = 0L;
+        private int totalPages = 0;
+        private boolean isFirst = true;
+        private boolean isLast = true;
+        private boolean hasNext = false;
+        private boolean hasPrevious = false;
+        private List<SearchedExhibition> exhibitions = List.of();
+
+        public Builder page(int page) {
+            this.page = page;
+            return this;
+        }
+
+        public Builder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder totalElements(long totalElements) {
+            this.totalElements = totalElements;
+            return this;
+        }
+
+        public Builder totalPages(int totalPages) {
+            this.totalPages = totalPages;
+            return this;
+        }
+
+        public Builder isFirst(boolean isFirst) {
+            this.isFirst = isFirst;
+            return this;
+        }
+
+        public Builder isLast(boolean isLast) {
+            this.isLast = isLast;
+            return this;
+        }
+
+        public Builder hasNext(boolean hasNext) {
+            this.hasNext = hasNext;
+            return this;
+        }
+
+        public Builder hasPrevious(boolean hasPrevious) {
+            this.hasPrevious = hasPrevious;
+            return this;
+        }
+
+        public MyExhibitionSearchResult build() {
+            return MyExhibitionSearchResult.builder()
+                    .page(page)
+                    .size(size)
+                    .totalElements(totalElements)
+                    .totalPages(totalPages)
+                    .isFirst(isFirst)
+                    .isLast(isLast)
+                    .hasNext(hasNext)
+                    .hasPrevious(hasPrevious)
+                    .exhibitions(exhibitions)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용
- ExhibitionQueryControllerTest에 searchMyExhibition 테스트 케이스 추가
  - 유효한 요청 시 200 반환 검증
  - 유효하지 않은 keyword(1자/101자) 시 400 반환 검증
  - 음수 page 시 400 반환 검증
  - 유효하지 않은 size(0/51) 시 400 반환 검증
- MyExhibitionSearchResultFixture 추가 (MyExhibitionSearchResult 픽스처)

## 변경 이유
내 전시회 검색 API(ExhibitionQueryController.searchMyExhibition())에 대한
컨트롤러 레벨 테스트가 없어 요청 유효성 검증 및 응답 스펙을 확인하기 위해 추가하였습니다.

Closes #175