### PR TITLE
refactor: 테스트 클래스 내부에 각 테스트 대상 메서드를 @Nested로 구분

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionBookmarkCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionBookmarkCommandControllerTest.java
@@ -11,6 +11,7 @@ import com.benchpress200.photique.exhibition.application.command.port.in.AddExhi
 import com.benchpress200.photique.exhibition.application.command.port.in.CancelExhibitionBookmarkUseCase;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -34,60 +35,68 @@ public class ExhibitionBookmarkCommandControllerTest extends BaseControllerTest 
     @MockitoBean
     private CancelExhibitionBookmarkUseCase cancelExhibitionBookmarkUseCase;
 
-    @Test
-    @DisplayName("전시회 북마크 추가 요청 시 요청이 유효하면 201을 반환한다")
-    public void addExhibitionBookmark_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(addExhibitionBookmarkUseCase).addExhibitionBookmark(any());
+    @Nested
+    @DisplayName("전시회 북마크 추가")
+    class AddExhibitionBookmarkTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(addExhibitionBookmarkUseCase).addExhibitionBookmark(any());
 
-        // when
-        ResultActions resultActions = requestAddExhibitionBookmark("1");
+            // when
+            ResultActions resultActions = requestAddExhibitionBookmark("1");
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않으면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            doNothing().when(addExhibitionBookmarkUseCase).addExhibitionBookmark(any());
+
+            // when
+            ResultActions resultActions = requestAddExhibitionBookmark("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("전시회 북마크 추가 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void addExhibitionBookmark_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(addExhibitionBookmarkUseCase).addExhibitionBookmark(any());
+    @Nested
+    @DisplayName("전시회 북마크 취소")
+    class CancelExhibitionBookmark {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(cancelExhibitionBookmarkUseCase).cancelExhibitionBookmark(any());
 
-        // when
-        ResultActions resultActions = requestAddExhibitionBookmark("invalid");
+            // when
+            ResultActions resultActions = requestCancelExhibitionBookmark("1");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("전시회 북마크 취소 요청 시 요청이 유효하면 204를 반환한다")
-    public void cancelExhibitionBookmark_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(cancelExhibitionBookmarkUseCase).cancelExhibitionBookmark(any());
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않다면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            doNothing().when(cancelExhibitionBookmarkUseCase).cancelExhibitionBookmark(any());
 
-        // when
-        ResultActions resultActions = requestCancelExhibitionBookmark("1");
+            // when
+            ResultActions resultActions = requestCancelExhibitionBookmark("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("전시회 북마크 취소 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void cancelExhibitionBookmark_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(cancelExhibitionBookmarkUseCase).cancelExhibitionBookmark(any());
-
-        // when
-        ResultActions resultActions = requestCancelExhibitionBookmark("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestAddExhibitionBookmark(String exhibitionId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommandControllerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,622 +57,664 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private DeleteExhibitionUseCase deleteExhibitionUseCase;
 
-    @Test
-    @DisplayName("전시회 생성 요청 시 요청이 유효하면 201을 반환한다")
-    public void openExhibition_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
+    @Nested
+    @DisplayName("전시회 생성")
+    class OpenExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
 
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
 
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
 
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
 
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @ParameterizedTest
+        @DisplayName("제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidTitles")
+        public void whenTitleInvalid(String invalidTitle) throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .title(invalidTitle)
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidDescriptions")
+        public void whenDescriptionInvalid(String invalidDescription) throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .description(invalidDescription)
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("카드 색상이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidCardColors")
+        public void whenCardColorInvalid(String invalidCardColor) throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .cardColor(invalidCardColor)
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("태그 리스트가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidTags")
+        public void whenTagsInvalid(List<String> invalidTags) throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .tags(invalidTags)
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 목록이 null이면 400을 반환한다")
+        public void whenWorksNull() throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(null)
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 목록이 비어있으면 400을 반환한다")
+        public void whenWorksEmpty() throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(List.of())
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("작품 순서가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidDisplayOrders")
+        public void whenWorkDisplayOrderInvalid(Integer invalidDisplayOrder) throws Exception {
+            // given
+            ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
+                    .displayOrder(invalidDisplayOrder)
+                    .build();
+
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(List.of(work))
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("작품 제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidWorkTitles")
+        public void whenWorkTitleInvalid(String invalidWorkTitle) throws Exception {
+            // given
+            ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
+                    .title(invalidWorkTitle)
+                    .build();
+
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(List.of(work))
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("작품 설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidWorkDescriptions")
+        public void whenWorkDescriptionInvalid(String invalidWorkDescription) throws Exception {
+            // given
+            ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
+                    .description(invalidWorkDescription)
+                    .build();
+
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(List.of(work))
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 순서가 중복되면 400을 반환한다")
+        public void whenWorkDisplayOrderDuplicated() throws Exception {
+            // given
+            ExhibitionWorkCreateRequest work1 = ExhibitionWorkCreateRequestFixture.builder()
+                    .displayOrder(0)
+                    .build();
+
+            ExhibitionWorkCreateRequest work2 = ExhibitionWorkCreateRequestFixture.builder()
+                    .displayOrder(0)
+                    .build();
+
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
+                    .works(List.of(work1, work2))
+                    .build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGES)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이미지 파일이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidImages")
+        public void whenImageInvalid(MockMultipartFile invalidImage) throws Exception {
+            // given
+            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
+
+            MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.EXHIBITION)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            doNothing().when(openExhibitionUseCase).openExhibition(any());
+
+            // when
+            ResultActions resultActions = requestOpenExhibition(exhibitionPart, invalidImage);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTitles")
-    public void openExhibition_whenTitleIsInvalid(String invalidTitle) throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .title(invalidTitle)
-                .build();
+    @Nested
+    @DisplayName("전시회 수정")
+    class UpdateExhibitionDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
 
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
 
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
+        @ParameterizedTest
+        @DisplayName("제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidTitlesForUpdate")
+        public void whenTitleInvalid(String invalidTitle) throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateTitle(true)
+                    .title(invalidTitle)
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
 
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidDescriptionsForUpdate")
+        public void whenDescriptionInvalid(String invalidDescription) throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateDescription(true)
+                    .description(invalidDescription)
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("카드 색상이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidCardColorsForUpdate")
+        public void whenCardColorInvalid(String invalidCardColor) throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateCardColor(true)
+                    .cardColor(invalidCardColor)
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("태그 리스트가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidTagsForUpdate")
+        public void whenTagsInvalid(List<String> invalidTags) throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateTags(true)
+                    .tags(invalidTags)
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 목록이 null이면 400을 반환한다")
+        public void whenWorksNull() throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(null)
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 목록이 비어있으면 400을 반환한다")
+        public void whenWorksEmpty() throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(List.of())
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("작품 ID가 유효하지 않다면 400을 반환한다")
+        public void whenWorkIdInvalid() throws Exception {
+            // given
+            ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                    .id(null)
+                    .build();
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(List.of(work))
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("작품 순서가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidDisplayOrdersForUpdate")
+        public void whenWorkDisplayOrderInvalid(Integer invalidDisplayOrder)
+                throws Exception {
+            // given
+            ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                    .displayOrder(invalidDisplayOrder)
+                    .build();
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(List.of(work))
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidWorkTitlesForUpdate")
+        public void whenWorkTitleInvalid(String invalidWorkTitle) throws Exception {
+            // given
+            ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                    .title(invalidWorkTitle)
+                    .build();
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(List.of(work))
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("작품 설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommandControllerTest#invalidWorkDescriptionsForUpdate")
+        public void whenWorkDescriptionInvalid(String invalidWorkDescription)
+                throws Exception {
+            // given
+            ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
+                    .description(invalidWorkDescription)
+                    .build();
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
+                    .updateWorks(true)
+                    .works(List.of(work))
+                    .build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않으면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
+            doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionDetails("invalid", request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDescriptions")
-    public void openExhibition_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .description(invalidDescription)
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 카드 색상이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidCardColors")
-    public void openExhibition_whenCardColorIsInvalid(String invalidCardColor) throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .cardColor(invalidCardColor)
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTags")
-    public void openExhibition_whenTagsIsInvalid(List<String> invalidTags) throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .tags(invalidTags)
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 생성 요청 시 작품 목록이 null이면 400을 반환한다")
-    public void openExhibition_whenWorksIsNull() throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(null)
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 생성 요청 시 작품 목록이 비어있으면 400을 반환한다")
-    public void openExhibition_whenWorksIsEmpty() throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(List.of())
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 작품 순서가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDisplayOrders")
-    public void openExhibition_whenWorkDisplayOrderIsInvalid(Integer invalidDisplayOrder) throws Exception {
-        // given
-        ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
-                .displayOrder(invalidDisplayOrder)
-                .build();
-
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(List.of(work))
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 작품 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidWorkTitles")
-    public void openExhibition_whenWorkTitleIsInvalid(String invalidWorkTitle) throws Exception {
-        // given
-        ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
-                .title(invalidWorkTitle)
-                .build();
-
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(List.of(work))
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 작품 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidWorkDescriptions")
-    public void openExhibition_whenWorkDescriptionIsInvalid(String invalidWorkDescription) throws Exception {
-        // given
-        ExhibitionWorkCreateRequest work = ExhibitionWorkCreateRequestFixture.builder()
-                .description(invalidWorkDescription)
-                .build();
-
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(List.of(work))
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 생성 요청 시 작품 순서가 중복되면 400을 반환한다")
-    public void openExhibition_whenWorkDisplayOrderIsDuplicated() throws Exception {
-        // given
-        ExhibitionWorkCreateRequest work1 = ExhibitionWorkCreateRequestFixture.builder()
-                .displayOrder(0)
-                .build();
-
-        ExhibitionWorkCreateRequest work2 = ExhibitionWorkCreateRequestFixture.builder()
-                .displayOrder(0)
-                .build();
-
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder()
-                .works(List.of(work1, work2))
-                .build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGES)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 생성 요청 시 이미지 파일이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidImages")
-    public void openExhibition_whenImageIsInvalid(MockMultipartFile invalidImage) throws Exception {
-        // given
-        ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-
-        MockMultipartFile exhibitionPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.EXHIBITION)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        doNothing().when(openExhibitionUseCase).openExhibition(any());
-
-        // when
-        ResultActions resultActions = requestOpenExhibition(exhibitionPart, invalidImage);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateExhibitionDetails_whenRequestIsValid() throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTitlesForUpdate")
-    public void updateExhibitionDetails_whenTitleIsInvalid(String invalidTitle) throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateTitle(true)
-                .title(invalidTitle)
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDescriptionsForUpdate")
-    public void updateExhibitionDetails_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateDescription(true)
-                .description(invalidDescription)
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 카드 색상이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidCardColorsForUpdate")
-    public void updateExhibitionDetails_whenCardColorIsInvalid(String invalidCardColor) throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateCardColor(true)
-                .cardColor(invalidCardColor)
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTagsForUpdate")
-    public void updateExhibitionDetails_whenTagsIsInvalid(List<String> invalidTags) throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateTags(true)
-                .tags(invalidTags)
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 수정 요청 시 작품 목록이 null이면 400을 반환한다")
-    public void updateExhibitionDetails_whenWorksIsNull() throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(null)
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 수정 요청 시 작품 목록이 비어있으면 400을 반환한다")
-    public void updateExhibitionDetails_whenWorksIsEmpty() throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(List.of())
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 수정 요청 시 작품 ID가 null이면 400을 반환한다")
-    public void updateExhibitionDetails_whenWorkIdIsNull() throws Exception {
-        // given
-        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
-                .id(null)
-                .build();
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(List.of(work))
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 작품 순서가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDisplayOrdersForUpdate")
-    public void updateExhibitionDetails_whenWorkDisplayOrderIsInvalid(Integer invalidDisplayOrder) throws Exception {
-        // given
-        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
-                .displayOrder(invalidDisplayOrder)
-                .build();
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(List.of(work))
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 작품 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidWorkTitlesForUpdate")
-    public void updateExhibitionDetails_whenWorkTitleIsInvalid(String invalidWorkTitle) throws Exception {
-        // given
-        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
-                .title(invalidWorkTitle)
-                .build();
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(List.of(work))
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 수정 요청 시 작품 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidWorkDescriptionsForUpdate")
-    public void updateExhibitionDetails_whenWorkDescriptionIsInvalid(String invalidWorkDescription) throws Exception {
-        // given
-        ExhibitionWorkUpdateRequest work = ExhibitionWorkUpdateRequestFixture.builder()
-                .description(invalidWorkDescription)
-                .build();
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder()
-                .updateWorks(true)
-                .works(List.of(work))
-                .build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("전시회 수정 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void updateExhibitionDetails_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        Map<String, Object> request = ExhibitionUpdateRequestFixture.builder().build();
-        doNothing().when(updateExhibitionDetailsUseCase).updateExhibitionDetailsUpdate(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionDetails("invalid", request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+    @Nested
+    @DisplayName("전시회 삭제")
+    class DeleteExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
+
+            // when
+            ResultActions resultActions = requestDeleteExhibition("1");
+
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않다면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
+
+            // when
+            ResultActions resultActions = requestDeleteExhibition("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidTitles() {
@@ -852,34 +895,6 @@ public class ExhibitionCommandControllerTest extends BaseControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );
-    }
-
-    @Test
-    @DisplayName("전시회 삭제 요청 시 요청이 유효하면 204를 반환한다")
-    public void deleteExhibition_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
-
-        // when
-        ResultActions resultActions = requestDeleteExhibition("1");
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("전시회 삭제 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void deleteExhibition_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(deleteExhibitionUseCase).deleteExhibition(any());
-
-        // when
-        ResultActions resultActions = requestDeleteExhibition("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
     }
 
     private ResultActions requestDeleteExhibition(String exhibitionId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionCommentCommandControllerTest.java
@@ -18,6 +18,7 @@ import com.benchpress200.photique.exhibition.application.command.port.in.UpdateE
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,37 +48,110 @@ public class ExhibitionCommentCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private DeleteExhibitionCommentUseCase deleteExhibitionCommentUseCase;
 
-    @Test
-    @DisplayName("전시회 감상평 생성 요청 시 요청이 유효하면 201을 반환한다")
-    public void createExhibitionComment_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder().build();
-        doNothing().when(createExhibitionCommentUseCase).createExhibitionComment(any());
+    @Nested
+    @DisplayName("전시회 감상평 생성")
+    class CreateExhibitionCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder().build();
+            doNothing().when(createExhibitionCommentUseCase).createExhibitionComment(any());
 
-        // when
-        ResultActions resultActions = requestCreateExhibitionComment(1L, request);
+            // when
+            ResultActions resultActions = requestCreateExhibitionComment(1L, request);
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @ParameterizedTest
+        @DisplayName("내용이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommentCommandControllerTest#invalidContents")
+        public void whenContentInvalid(String invalidContent) throws Exception {
+            // given
+            ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder()
+                    .content(invalidContent)
+                    .build();
+            doNothing().when(createExhibitionCommentUseCase).createExhibitionComment(any());
+
+            // when
+            ResultActions resultActions = requestCreateExhibitionComment(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("전시회 감상평 생성 요청 시 내용이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidContents")
-    public void createExhibitionComment_whenContentIsInvalid(String invalidContent) throws Exception {
-        // given
-        ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder()
-                .content(invalidContent)
-                .build();
-        doNothing().when(createExhibitionCommentUseCase).createExhibitionComment(any());
+    @Nested
+    @DisplayName("전시회 감상평 수정")
+    class UpdateExhibitionCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder().build();
+            doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
 
-        // when
-        ResultActions resultActions = requestCreateExhibitionComment(1L, request);
+            // when
+            ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @ParameterizedTest
+        @DisplayName("내용이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.command.controller.ExhibitionCommentCommandControllerTest#invalidContentsForUpdate")
+        public void whenContentInvalid(String invalidContent) throws Exception {
+            // given
+            ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder()
+                    .content(invalidContent)
+                    .build();
+            doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
+
+            // when
+            ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("전시회 감상평 삭제")
+    class DeleteExhibitionCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
+
+            // when
+            ResultActions resultActions = requestDeleteExhibitionComment("1");
+
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("감상평 ID가 유효하지 않다면 400을 반환한다")
+        public void whenCommentIdInvalid() throws Exception {
+            // given
+            doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
+
+            // when
+            ResultActions resultActions = requestDeleteExhibitionComment("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidContents() {
@@ -100,39 +174,6 @@ public class ExhibitionCommentCommandControllerTest extends BaseControllerTest {
         );
     }
 
-    @Test
-    @DisplayName("전시회 감상평 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateExhibitionComment_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder().build();
-        doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 감상평 수정 요청 시 내용이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidContentsForUpdate")
-    public void updateExhibitionComment_whenContentIsInvalid(String invalidContent) throws Exception {
-        // given
-        ExhibitionCommentUpdateRequest request = ExhibitionCommentUpdateRequestFixture.builder()
-                .content(invalidContent)
-                .build();
-        doNothing().when(updateExhibitionCommentUseCase).updateExhibitionComment(any());
-
-        // when
-        ResultActions resultActions = requestUpdateExhibitionComment(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
     private static Stream<String> invalidContentsForUpdate() {
         return Stream.of(
                 null,
@@ -151,34 +192,6 @@ public class ExhibitionCommentCommandControllerTest extends BaseControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );
-    }
-
-    @Test
-    @DisplayName("전시회 감상평 삭제 요청 시 요청이 유효하면 204를 반환한다")
-    public void deleteExhibitionComment_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
-
-        // when
-        ResultActions resultActions = requestDeleteExhibitionComment("1");
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("전시회 감상평 삭제 요청 시 감상평 ID가 숫자가 아니면 400을 반환한다")
-    public void deleteExhibitionComment_whenCommentIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(deleteExhibitionCommentUseCase).deleteExhibitionComment(any());
-
-        // when
-        ResultActions resultActions = requestDeleteExhibitionComment("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
     }
 
     private ResultActions requestDeleteExhibitionComment(String commentId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionLikeCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/command/controller/ExhibitionLikeCommandControllerTest.java
@@ -11,6 +11,7 @@ import com.benchpress200.photique.exhibition.application.command.port.in.AddExhi
 import com.benchpress200.photique.exhibition.application.command.port.in.CancelExhibitionLikeUseCase;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -34,60 +35,68 @@ public class ExhibitionLikeCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private CancelExhibitionLikeUseCase cancelExhibitionLikeUseCase;
 
-    @Test
-    @DisplayName("전시회 좋아요 추가 요청 시 요청이 유효하면 201을 반환한다")
-    public void addExhibitionLike_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(addExhibitionLikeUseCase).addExhibitionLike(any());
+    @Nested
+    @DisplayName("전시회 좋아요 추가")
+    class AddExhibitionLikeTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(addExhibitionLikeUseCase).addExhibitionLike(any());
 
-        // when
-        ResultActions resultActions = requestAddExhibitionLike("1");
+            // when
+            ResultActions resultActions = requestAddExhibitionLike("1");
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않다면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            doNothing().when(addExhibitionLikeUseCase).addExhibitionLike(any());
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLike("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("전시회 좋아요 추가 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void addExhibitionLike_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(addExhibitionLikeUseCase).addExhibitionLike(any());
+    @Nested
+    @DisplayName("전시회 좋아요 취소")
+    class CancelExhibitionLikeTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(cancelExhibitionLikeUseCase).cancelExhibitionLike(any());
 
-        // when
-        ResultActions resultActions = requestAddExhibitionLike("invalid");
+            // when
+            ResultActions resultActions = requestCancelExhibitionLike("1");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("전시회 좋아요 취소 요청 시 요청이 유효하면 204를 반환한다")
-    public void cancelExhibitionLike_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(cancelExhibitionLikeUseCase).cancelExhibitionLike(any());
+        @Test
+        @DisplayName("전시회 ID가 숫자가 아니면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            doNothing().when(cancelExhibitionLikeUseCase).cancelExhibitionLike(any());
 
-        // when
-        ResultActions resultActions = requestCancelExhibitionLike("1");
+            // when
+            ResultActions resultActions = requestCancelExhibitionLike("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("전시회 좋아요 취소 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void cancelExhibitionLike_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(cancelExhibitionLikeUseCase).cancelExhibitionLike(any());
-
-        // when
-        ResultActions resultActions = requestCancelExhibitionLike("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestAddExhibitionLike(String exhibitionId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionBookmarkQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionBookmarkQueryControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.exhibition.application.query.support.fixture.B
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,66 +35,70 @@ public class ExhibitionBookmarkQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchBookmarkedExhibitionUseCase searchBookmarkedExhibitionUseCase;
 
-    @Test
-    @DisplayName("북마크 전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchBookmarkedExhibition_whenRequestIsValid() throws Exception {
-        // given
-        BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
+    @Nested
+    @DisplayName("북마크 전시회 검색")
+    class SearchBookmarkedExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchBookmarkedExhibition(null, null, null);
+            // when
+            ResultActions resultActions = requestSearchBookmarkedExhibition(null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @ParameterizedTest
-    @DisplayName("북마크 전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchBookmarkedExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-        BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionBookmarkQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchBookmarkedExhibition(invalidKeyword, null, null);
+            // when
+            ResultActions resultActions = requestSearchBookmarkedExhibition(invalidKeyword, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("북마크 전시회 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchBookmarkedExhibition_whenPageIsNegative() throws Exception {
-        // given
-        BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않다면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchBookmarkedExhibition(null, "-1", null);
+            // when
+            ResultActions resultActions = requestSearchBookmarkedExhibition(null, "-1", null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("북마크 전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchBookmarkedExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionBookmarkQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            BookmarkedExhibitionSearchResult result = BookmarkedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchBookmarkedExhibitionUseCase).searchBookmarkedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchBookmarkedExhibition(null, null, invalidSize);
+            // when
+            ResultActions resultActions = requestSearchBookmarkedExhibition(null, null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywords() {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionCommentQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionCommentQueryControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.exhibition.application.query.support.fixture.E
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,65 +35,69 @@ public class ExhibitionCommentQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private GetExhibitionCommentsUseCase getExhibitionCommentsUseCase;
 
-    @Test
-    @DisplayName("전시회 감상평 조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getExhibitionComments_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
+    @Nested
+    @DisplayName("전시회 감상평 페이지 조회")
+    class GetExhibitionCommentsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionComments("1", null, null);
+            // when
+            ResultActions resultActions = requestGetExhibitionComments("1", null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("전시회 감상평 조회 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void getExhibitionComments_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않다면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionComments("invalid", null, null);
+            // when
+            ResultActions resultActions = requestGetExhibitionComments("invalid", null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("전시회 감상평 조회 요청 시 page가 음수이면 400을 반환한다")
-    public void getExhibitionComments_whenPageIsNegative() throws Exception {
-        // given
-        ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않다면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionComments("1", "-1", null);
+            // when
+            ResultActions resultActions = requestGetExhibitionComments("1", "-1", null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("전시회 감상평 조회 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void getExhibitionComments_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionCommentQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            ExhibitionCommentsResult result = ExhibitionCommentsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionCommentsUseCase).getExhibitionComments(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionComments("1", null, invalidSize);
+            // when
+            ResultActions resultActions = requestGetExhibitionComments("1", null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidSizes() {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionLikeQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionLikeQueryControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.exhibition.application.query.support.fixture.L
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,66 +35,70 @@ public class ExhibitionLikeQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchLikedExhibitionUseCase searchLikedExhibitionUseCase;
 
-    @Test
-    @DisplayName("좋아요 전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchLikedExhibition_whenRequestIsValid() throws Exception {
-        // given
-        LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
+    @Nested
+    @DisplayName("좋아요한 전시회 검색")
+    class SearchLikedExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchLikedExhibition(null, null, null);
+            // when
+            ResultActions resultActions = requestSearchLikedExhibition(null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @ParameterizedTest
-    @DisplayName("좋아요 전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchLikedExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-        LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionLikeQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchLikedExhibition(invalidKeyword, null, null);
+            // when
+            ResultActions resultActions = requestSearchLikedExhibition(invalidKeyword, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("좋아요 전시회 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchLikedExhibition_whenPageIsNegative() throws Exception {
-        // given
-        LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않다면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchLikedExhibition(null, "-1", null);
+            // when
+            ResultActions resultActions = requestSearchLikedExhibition(null, "-1", null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("좋아요 전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchLikedExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionLikeQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            LikedExhibitionSearchResult result = LikedExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchLikedExhibitionUseCase).searchLikedExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchLikedExhibition(null, null, invalidSize);
+            // when
+            ResultActions resultActions = requestSearchLikedExhibition(null, null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywords() {

--- a/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/api/query/controller/ExhibitionQueryControllerTest.java
@@ -18,6 +18,7 @@ import com.benchpress200.photique.singlework.application.query.support.fixture.M
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,205 +48,217 @@ public class ExhibitionQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchMyExhibitionUseCase searchMyExhibitionUseCase;
 
-    @Test
-    @DisplayName("전시회 상세조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getExhibitionDetails_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
+    @Nested
+    @DisplayName("전시회 상세 조회")
+    class GetExhibitionDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionDetails("1");
+            // when
+            ResultActions resultActions = requestGetExhibitionDetails("1");
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("전시회 ID가 유효하지 않다면 400을 반환한다")
+        public void whenExhibitionIdInvalid() throws Exception {
+            // given
+            ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
+            doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
+
+            // when
+            ResultActions resultActions = requestGetExhibitionDetails("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("전시회 상세조회 요청 시 전시회 ID가 숫자가 아니면 400을 반환한다")
-    public void getExhibitionDetails_whenExhibitionIdIsNotNumber() throws Exception {
-        // given
-        ExhibitionDetailsResult result = ExhibitionDetailsResultFixture.builder().build();
-        doReturn(result).when(getExhibitionDetailsUseCase).getExhibitionDetails(any());
+    @Nested
+    @DisplayName("전시회 검색")
+    class SearchExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
 
-        // when
-        ResultActions resultActions = requestGetExhibitionDetails("invalid");
+            // when
+            ResultActions resultActions = requestSearchExhibition(
+                    get(ApiPath.EXHIBITION_ROOT)
+                            .param("target", "work")
+                            .param("keyword", "기본키워드")
+                            .param("page", "0")
+                            .param("size", "10")
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("검색 대상이 유효하지 않으면 400을 반환한다")
+        public void whenTargetInvalid() throws Exception {
+            // given
+            ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+            // when
+            ResultActions resultActions = requestSearchExhibition(
+                    get(ApiPath.EXHIBITION_ROOT)
+                            .param("target", "invalid")
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+            // when
+            ResultActions resultActions = requestSearchExhibition(
+                    get(ApiPath.EXHIBITION_ROOT)
+                            .param("keyword", invalidKeyword)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않다면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+            // when
+            ResultActions resultActions = requestSearchExhibition(
+                    get(ApiPath.EXHIBITION_ROOT)
+                            .param("page", "-1")
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+
+            // when
+            ResultActions resultActions = requestSearchExhibition(
+                    get(ApiPath.EXHIBITION_ROOT)
+                            .param("size", invalidSize)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchExhibition_whenRequestIsValid() throws Exception {
-        // given
-        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+    @Nested
+    @DisplayName("내 전시회 검색")
+    class SearchMyExhibitionTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchExhibition(
-                get(ApiPath.EXHIBITION_ROOT)
-                        .param("target", "work")
-                        .param("keyword", "기본키워드")
-                        .param("page", "0")
-                        .param("size", "10")
-        );
+            // when
+            ResultActions resultActions = requestSearchMyExhibition(
+                    get(ApiPath.EXHIBITION_MY_DATA)
+                            .param("keyword", "기본키워드")
+                            .param("page", "0")
+                            .param("size", "10")
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("전시회 검색 요청 시 target이 유효하지 않으면 400을 반환한다")
-    public void searchExhibition_whenTargetIsInvalid() throws Exception {
-        // given
-        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchExhibition(
-                get(ApiPath.EXHIBITION_ROOT)
-                        .param("target", "invalid")
-        );
+            // when
+            ResultActions resultActions = requestSearchMyExhibition(
+                    get(ApiPath.EXHIBITION_MY_DATA)
+                            .param("keyword", invalidKeyword)
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않다면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchExhibition(
-                get(ApiPath.EXHIBITION_ROOT)
-                        .param("keyword", invalidKeyword)
-        );
+            // when
+            ResultActions resultActions = requestSearchMyExhibition(
+                    get(ApiPath.EXHIBITION_MY_DATA)
+                            .param("page", "-1")
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("전시회 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchExhibition_whenPageIsNegative() throws Exception {
-        // given
-        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.exhibition.api.query.controller.ExhibitionQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
+            doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
 
-        // when
-        ResultActions resultActions = requestSearchExhibition(
-                get(ApiPath.EXHIBITION_ROOT)
-                        .param("page", "-1")
-        );
+            // when
+            ResultActions resultActions = requestSearchMyExhibition(
+                    get(ApiPath.EXHIBITION_MY_DATA)
+                            .param("size", invalidSize)
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        ExhibitionSearchResult result = ExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchExhibitionUseCase).searchExhibition(any());
-
-        // when
-        ResultActions resultActions = requestSearchExhibition(
-                get(ApiPath.EXHIBITION_ROOT)
-                        .param("size", invalidSize)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("내 전시회 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchMyExhibition_whenRequestIsValid() throws Exception {
-        // given
-        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
-
-        // when
-        ResultActions resultActions = requestSearchMyExhibition(
-                get(ApiPath.EXHIBITION_MY_DATA)
-                        .param("keyword", "기본키워드")
-                        .param("page", "0")
-                        .param("size", "10")
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
-
-    @ParameterizedTest
-    @DisplayName("내 전시회 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchMyExhibition_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
-
-        // when
-        ResultActions resultActions = requestSearchMyExhibition(
-                get(ApiPath.EXHIBITION_MY_DATA)
-                        .param("keyword", invalidKeyword)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("내 전시회 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchMyExhibition_whenPageIsNegative() throws Exception {
-        // given
-        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
-
-        // when
-        ResultActions resultActions = requestSearchMyExhibition(
-                get(ApiPath.EXHIBITION_MY_DATA)
-                        .param("page", "-1")
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("내 전시회 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchMyExhibition_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        MyExhibitionSearchResult result = MyExhibitionSearchResultFixture.builder().build();
-        doReturn(result).when(searchMyExhibitionUseCase).searchMyExhibition(any());
-
-        // when
-        ResultActions resultActions = requestSearchMyExhibition(
-                get(ApiPath.EXHIBITION_MY_DATA)
-                        .param("size", invalidSize)
-        );
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywords() {

--- a/src/test/java/com/benchpress200/photique/notification/api/command/controller/NotificationCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/notification/api/command/controller/NotificationCommandControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.notification.application.command.port.in.MarkA
 import com.benchpress200.photique.notification.application.command.port.in.MarkAsReadUseCase;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -38,74 +39,86 @@ public class NotificationCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private DeleteNotificationUseCase deleteNotificationUseCase;
 
-    @Test
-    @DisplayName("알림 읽음 표시 요청 시 요청이 유효하면 204를 반환한다")
-    public void markAsRead_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(markAsReadUseCase).markAsRead(any());
+    @Nested
+    @DisplayName("알림 읽음 표시")
+    class MarkAsReadTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(markAsReadUseCase).markAsRead(any());
 
-        // when
-        ResultActions resultActions = requestMarkAsRead("1");
+            // when
+            ResultActions resultActions = requestMarkAsRead("1");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("알림 ID가 숫자가 아니면 400을 반환한다")
+        public void whenNotificationIdInvalid() throws Exception {
+            // given
+            doNothing().when(markAsReadUseCase).markAsRead(any());
+
+            // when
+            ResultActions resultActions = requestMarkAsRead("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("알림 읽음 표시 요청 시 알림 ID가 숫자가 아니면 400을 반환한다")
-    public void markAsRead_whenNotificationIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(markAsReadUseCase).markAsRead(any());
+    @Nested
+    @DisplayName("알림 전체 읽음 표시")
+    class MarkAllAsReadTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(markAllAsReadUseCase).markAllAsRead();
 
-        // when
-        ResultActions resultActions = requestMarkAsRead("invalid");
+            // when
+            ResultActions resultActions = requestMarkAllAsRead();
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
     }
 
-    @Test
-    @DisplayName("알림 전체 읽음 표시 요청 시 요청이 유효하면 204를 반환한다")
-    public void markAllAsRead_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(markAllAsReadUseCase).markAllAsRead();
+    @Nested
+    @DisplayName("알림 전체 읽음 표시")
+    class DeleteNotificationTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(deleteNotificationUseCase).deleteNotification(any());
 
-        // when
-        ResultActions resultActions = requestMarkAllAsRead();
+            // when
+            ResultActions resultActions = requestDeleteNotification("1");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("알림 삭제 요청 시 요청이 유효하면 204를 반환한다")
-    public void deleteNotification_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(deleteNotificationUseCase).deleteNotification(any());
+        @Test
+        @DisplayName("알림 ID가 숫자가 아니면 400을 반환한다")
+        public void whenNotificationIdInvalid() throws Exception {
+            // given
+            doNothing().when(deleteNotificationUseCase).deleteNotification(any());
 
-        // when
-        ResultActions resultActions = requestDeleteNotification("1");
+            // when
+            ResultActions resultActions = requestDeleteNotification("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("알림 삭제 요청 시 알림 ID가 숫자가 아니면 400을 반환한다")
-    public void deleteNotification_whenNotificationIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(deleteNotificationUseCase).deleteNotification(any());
-
-        // when
-        ResultActions resultActions = requestDeleteNotification("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestMarkAsRead(String notificationId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/notification/api/query/controller/NotificationQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/notification/api/query/controller/NotificationQueryControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.notification.application.query.support.fixture
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,62 +36,66 @@ public class NotificationQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private GetNotificationPageUserCase getNotificationPageUserCase;
 
-    @Test
-    @DisplayName("알림 페이지 조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getNotificationPage_whenRequestIsValid() throws Exception {
-        // given
-        NotificationPageResult result = NotificationPageResultFixture.builder().build();
-        doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
+    @Nested
+    @DisplayName("알림 페이지 조회")
+    class GetNotificationPageTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            NotificationPageResult result = NotificationPageResultFixture.builder().build();
+            doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
 
-        // when
-        ResultActions resultActions = requestGetNotificationPage(
-                get(ApiPath.NOTIFICATION_ROOT)
-                        .param("page", "0")
-                        .param("size", "10")
-        );
+            // when
+            ResultActions resultActions = requestGetNotificationPage(
+                    get(ApiPath.NOTIFICATION_ROOT)
+                            .param("page", "0")
+                            .param("size", "10")
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("알림 페이지 조회 요청 시 page가 음수이면 400을 반환한다")
-    public void getNotificationPage_whenPageIsNegative() throws Exception {
-        // given
-        NotificationPageResult result = NotificationPageResultFixture.builder().build();
-        doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
+        @Test
+        @DisplayName("페이지 번호가 유효하지 않으면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            NotificationPageResult result = NotificationPageResultFixture.builder().build();
+            doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
 
-        // when
-        ResultActions resultActions = requestGetNotificationPage(
-                get(ApiPath.NOTIFICATION_ROOT)
-                        .param("page", "-1")
-                        .param("size", "10")
-        );
+            // when
+            ResultActions resultActions = requestGetNotificationPage(
+                    get(ApiPath.NOTIFICATION_ROOT)
+                            .param("page", "-1")
+                            .param("size", "10")
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("알림 페이지 조회 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void getNotificationPage_whenSizeIsInvalid(String invalidSize) throws Exception {
-        // given
-        NotificationPageResult result = NotificationPageResultFixture.builder().build();
-        doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.notification.api.query.controller.NotificationQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(String invalidSize) throws Exception {
+            // given
+            NotificationPageResult result = NotificationPageResultFixture.builder().build();
+            doReturn(result).when(getNotificationPageUserCase).getNotificationPage(any());
 
-        // when
-        ResultActions resultActions = requestGetNotificationPage(
-                get(ApiPath.NOTIFICATION_ROOT)
-                        .param("page", "0")
-                        .param("size", invalidSize)
-        );
+            // when
+            ResultActions resultActions = requestGetNotificationPage(
+                    get(ApiPath.NOTIFICATION_ROOT)
+                            .param("page", "0")
+                            .param("size", invalidSize)
+            );
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidSizes() {

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommandControllerTest.java
@@ -22,6 +22,7 @@ import com.benchpress200.photique.support.fixture.MultipartJsonFixture;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,631 +54,647 @@ public class SingleWorkCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private DeleteSingleWorkUseCase deleteSingleWorkUseCase;
 
+    @Nested
+    @DisplayName("단일작품 생성")
+    class PostSingleWorkTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build(); // 기본값으로 객체 생성
 
-    @Test
-    @DisplayName("단일작품 생성 요청 시 요청이 유효하면 201을 반환한다")
-    public void postSingleWork_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build(); // 기본값으로 객체 생성
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
 
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
 
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
 
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
 
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+        @ParameterizedTest
+        @DisplayName("제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidTitle")
+        // null, 빈 문자열, 31자 제목
+        public void whenTitleInvalid(String invalidTitle) throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .title(invalidTitle)
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            //when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            //then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidDescriptions")
+        // null, 빈 문자열, 501자 설명
+        public void whenDescriptionInvalid(String invalidDescription) throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .description(invalidDescription)
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            //when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            //then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("카메라 이름이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidCamera")
+        // null, 빈 문자열, 31자 카메라 이름
+        public void whenCameraInvalid(String invalidCamera) throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .camera(invalidCamera)
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            //when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            //then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("렌즈 이름이 유효하지 않으면 400을 반환한다")
+        public void whenLensInvalid() throws Exception {
+            // given
+            int invalidLength = 31; // 30자 초과
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .lens("a".repeat(invalidLength))
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("조리개 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
+        public void whenApertureInvalid() throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .aperture("f/123")
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("셔터스피드 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
+        public void whenShutterSpeedInvalid() throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .shutterSpeed("-50")
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("ISO 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
+        public void whenISOInvalid() throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .iso("-1000")
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("카테고리가 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
+        public void whenCategoryInvalid() throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .category("두릅비빔")
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("장소 이름이 유효하지 않다면 400을 반환한다")
+        public void whenLocationInvalid() throws Exception {
+            // given
+            int invalidLength = 31; // 30자 초과
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .location("a".repeat(invalidLength))
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("촬영 날짜 포멧(yyyy-MM-dd)이 유효하지 않다면 400을 반환한다")
+        public void whenDateInvalid() throws Exception {
+            // given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .date(null)
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("태그 리스트가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidTag")
+        // 태그 개수 5개 초과, 공백 포함 태그, 태그 길이 10자 초과
+        public void whenTagInvalid(List<String> invalidTag) throws Exception {
+            //given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
+                    .tags(invalidTag)
+                    .build();
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            MockMultipartFile imagePart = MultipartFileFixture.builder()
+                    .key(MultipartKey.IMAGE)
+                    .fileName("test.jpg")
+                    .contentType(MediaType.IMAGE_JPEG_VALUE)
+                    .content(new byte[]{0})
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            //when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+
+            //then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이미지 파일이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidImage")
+        // 빈 파일, 5MB초과, 파일 이름 null, 다른 확장자
+        public void whenImageInvalid(MockMultipartFile invalidImage) throws Exception {
+            // given
+            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build(); // 기본값으로 객체 생성
+
+            MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.SINGLEWORK)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestPostSingleWork(singleWorkPart, invalidImage);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("단일작품 생성 요청 시 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTitle") // null, 빈 문자열, 31자 제목
-    public void postSingleWork_whenTitleIsInvalid(String invalidTitle) throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .title(invalidTitle)
-                .build();
+    @Nested
+    @DisplayName("단일작품 수정")
+    class UpdateSingleWorkDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
 
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
 
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
+        @ParameterizedTest
+        @DisplayName("제목이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidTitleForUpdate")
+        public void whenTitleInvalid(String invalidTitle) throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateTitle(true)
+                    .title(invalidTitle)
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
 
-        //when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
 
-        //then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("설명이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidDescriptionForUpdate")
+        public void whenDescriptionInvalid(String invalidDescription) throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateDescription(true)
+                    .description(invalidDescription)
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("카메라 이름이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidCameraForUpdate")
+        public void whenCameraInvalid(String invalidCamera) throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateCamera(true)
+                    .camera(invalidCamera)
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("렌즈 이름이 유효하지 않으면 400을 반환한다")
+        public void whenLensInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateLens(true)
+                    .lens("a".repeat(31))
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("조리개 값이 유효하지 않으면 400을 반환한다")
+        public void whenApertureInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateAperture(true)
+                    .aperture("f/123")
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("셔터스피드 값이 유효하지 않으면 400을 반환한다")
+        public void whenShutterSpeedInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateShutterSpeed(true)
+                    .shutterSpeed("-50")
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("ISO 값이 유효하지 않으면 400을 반환한다")
+        public void whenISOInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateIso(true)
+                    .iso("-1000")
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("카테고리 값이 유효하지 않으면 400을 반환한다")
+        public void whenCategoryInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateCategory(true)
+                    .category("두릅비빔")
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("장소 이름이 유효하지 않으면 400을 반환한다")
+        public void whenLocationInvalid() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateLocation(true)
+                    .location("a".repeat(31))
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("태그 리스트가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommandControllerTest#invalidTagForUpdate")
+        public void whenTagInvalid(List<String> invalidTags) throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .updateTags(true)
+                    .tags(invalidTags)
+                    .build();
+            doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("단일작품 생성 요청 시 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDescriptions") // null, 빈 문자열, 501자 설명
-    public void postSingleWork_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .description(invalidDescription)
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        //when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        //then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 생성 요청 시 카메라 이름이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidCamera") // null, 빈 문자열, 31자 카메라 이름
-    public void postSingleWork_whenCameraIsInvalid(String invalidCamera) throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .camera(invalidCamera)
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        //when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        //then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 렌즈 이름이 유효하지 않으면 400을 반환한다")
-    public void postSingleWork_whenLensIsInvalid() throws Exception {
-        // given
-        int invalidLength = 31; // 30자 초과
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .lens("a".repeat(invalidLength))
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 조리개 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
-    public void postSingleWork_whenApertureIsInvalid() throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .aperture("f/123")
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 셔터스피드 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
-    public void postSingleWork_whenShutterSpeedIsInvalid() throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .shutterSpeed("-50")
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 ISO 값이 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
-    public void postSingleWork_whenISOIsInvalid() throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .iso("-1000")
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 카테고리가 유효하지 않다면(enum에 속하지 않는 값) 400을 반환한다")
-    public void postSingleWork_whenCategoryIsInvalid() throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .category("두릅비빔")
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 장소 이름이 유효하지 않다면 400을 반환한다")
-    public void postSingleWork_whenLocationIsInvalid() throws Exception {
-        // given
-        int invalidLength = 31; // 30자 초과
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .location("a".repeat(invalidLength))
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 생성 요청 시 촬영 날짜 포멧(yyyy-MM-dd)이 유효하지 않다면 400을 반환한다")
-    public void postSingleWork_whenDateIsInvalid() throws Exception {
-        // given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .date(null)
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 생성 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTag") // 태그 개수 5개 초과, 공백 포함 태그, 태그 길이 10자 초과
-    public void postSingleWork_whenTagIsInvalid(List<String> invalidTag) throws Exception {
-        //given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder()
-                .tags(invalidTag)
-                .build();
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        MockMultipartFile imagePart = MultipartFileFixture.builder()
-                .key(MultipartKey.IMAGE)
-                .fileName("test.jpg")
-                .contentType(MediaType.IMAGE_JPEG_VALUE)
-                .content(new byte[]{0})
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        //when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, imagePart);
-
-        //then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 생성 요청 시 이미지 파일이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidImage") // 빈 파일, 5MB초과, 파일 이름 null, 다른 확장자
-    public void postSingleWork_whenImageIsInvalid(MockMultipartFile invalidImage) throws Exception {
-        // given
-        SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build(); // 기본값으로 객체 생성
-
-        MockMultipartFile singleWorkPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.SINGLEWORK)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-
-        doNothing().when(postSingleWorkUseCase).postSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestPostSingleWork(singleWorkPart, invalidImage);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateSingleWorkDetails_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 수정 요청 시 제목이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTitleForUpdate")
-    public void updateSingleWorkDetails_whenTitleIsInvalid(String invalidTitle) throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateTitle(true)
-                .title(invalidTitle)
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 수정 요청 시 설명이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidDescriptionForUpdate")
-    public void updateSingleWorkDetails_whenDescriptionIsInvalid(String invalidDescription) throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateDescription(true)
-                .description(invalidDescription)
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 수정 요청 시 카메라 이름이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidCameraForUpdate")
-    public void updateSingleWorkDetails_whenCameraIsInvalid(String invalidCamera) throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateCamera(true)
-                .camera(invalidCamera)
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 렌즈 이름이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenLensIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateLens(true)
-                .lens("a".repeat(31))
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 조리개 값이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenApertureIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateAperture(true)
-                .aperture("f/123")
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 셔터스피드 값이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenShutterSpeedIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateShutterSpeed(true)
-                .shutterSpeed("-50")
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 ISO 값이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenISOIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateIso(true)
-                .iso("-1000")
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 카테고리 값이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenCategoryIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateCategory(true)
-                .category("두릅비빔")
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 요청 시 장소 이름이 유효하지 않으면 400을 반환한다")
-    public void updateSingleWorkDetails_whenLocationIsInvalid() throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateLocation(true)
-                .location("a".repeat(31))
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 수정 요청 시 태그 리스트가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidTagForUpdate")
-    public void updateSingleWorkDetails_whenTagIsInvalid(List<String> invalidTags) throws Exception {
-        // given
-        SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
-                .updateTags(true)
-                .tags(invalidTags)
-                .build();
-        doNothing().when(updateSingleWorkDetailsUseCase).updateSingleWorkDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateSingleWork(1L, request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 삭제 요청 시 요청이 유효하면 204를 반환한다")
-    public void deleteSingleWork_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestDeleteSingleWork("1");
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("단일작품 삭제 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
-    public void deleteSingleWork_whenSingleWorkIdIsInvalid() throws Exception {
-        // given
-        doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
-
-        // when
-        ResultActions resultActions = requestDeleteSingleWork("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+    @Nested
+    @DisplayName("단일작품 삭제")
+    class DeleteSingleWorkTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestDeleteSingleWork("1");
+
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("작품 아이디가 숫자가 아니면 400을 반환한다")
+        public void whenSingleWorkIdInvalid() throws Exception {
+            // given
+            doNothing().when(deleteSingleWorkUseCase).deleteSingleWork(any());
+
+            // when
+            ResultActions resultActions = requestDeleteSingleWork("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidTitleForUpdate() {

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkCommentCommandControllerTest.java
@@ -18,6 +18,7 @@ import com.benchpress200.photique.singlework.application.command.port.in.UpdateS
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,99 +48,110 @@ public class SingleWorkCommentCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private DeleteSingleWorkCommentUseCase deleteSingleWorkCommentUseCase;
 
+    @Nested
+    @DisplayName("단일작품 댓글 생성")
+    class CreateSingleWorkCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder().build();
+            doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
 
-    @Test
-    @DisplayName("단일작품 댓글 생성 요청 시 요청이 유효하면 201을 반환한다")
-    public void createSingleWorkComment_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder().build();
-        doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
+            // when
+            ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
 
-        // when
-        ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+        @ParameterizedTest
+        @DisplayName("내용이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommentCommandControllerTest#invalidContent")
+        public void whenContentInvalid(String invalidContent) throws Exception {
+            // given
+            SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder()
+                    .content(invalidContent)
+                    .build();
+            doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
+
+            // when
+            ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("단일작품 댓글 생성 요청 시 내용이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidContent")
-    public void createSingleWorkComment_whenContentIsInvalid(String invalidContent) throws Exception {
-        // given
-        SingleWorkCommentCreateRequest request = SingleWorkCommentCreateRequestFixture.builder()
-                .content(invalidContent)
-                .build();
-        doNothing().when(createSingleWorkCommentUseCase).createSingleWorkComment(any());
+    @Nested
+    @DisplayName("단일작품 댓글 수정")
+    class UpdateSingleWorkCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder().build();
+            doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
 
-        // when
-        ResultActions resultActions = requestCreateSingleWorkComment(1L, request);
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @ParameterizedTest
+        @DisplayName("내용이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.command.controller.SingleWorkCommentCommandControllerTest#invalidContentForUpdate")
+        public void whenContentInvalid(String invalidContent) throws Exception {
+            // given
+            SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder()
+                    .content(invalidContent)
+                    .build();
+            doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 댓글 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateSingleWorkComment_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder().build();
-        doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
+    @Nested
+    @DisplayName("단일작품 댓글 삭제")
+    class DeleteSingleWorkCommentTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(deleteSingleWorkCommentUseCase).deleteSingleWorkComment(any());
 
-        // when
-        ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
+            // when
+            ResultActions resultActions = requestDeleteSingleWorkComment("1");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @ParameterizedTest
-    @DisplayName("단일작품 댓글 수정 요청 시 내용이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidContentForUpdate")
-    public void updateSingleWorkComment_whenContentIsInvalid(String invalidContent) throws Exception {
-        // given
-        SingleWorkCommentUpdateRequest request = SingleWorkCommentUpdateRequestFixture.builder()
-                .content(invalidContent)
-                .build();
-        doNothing().when(updateSingleWorkCommentUseCase).updateSingleWorkComment(any());
+        @Test
+        @DisplayName("댓글 ID가 숫자가 아니면 400을 반환한다")
+        public void whenCommentIdInvalid() throws Exception {
+            // given
+            doNothing().when(deleteSingleWorkCommentUseCase).deleteSingleWorkComment(any());
 
-        // when
-        ResultActions resultActions = requestUpdateSingleWorkComment(1L, request);
+            // when
+            ResultActions resultActions = requestDeleteSingleWorkComment("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("단일작품 댓글 삭제 요청 시 요청이 유효하면 204를 반환한다")
-    public void deleteSingleWorkComment_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(deleteSingleWorkCommentUseCase).deleteSingleWorkComment(any());
-
-        // when
-        ResultActions resultActions = requestDeleteSingleWorkComment("1");
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("단일작품 댓글 삭제 요청 시 댓글 ID가 숫자가 아니면 400을 반환한다")
-    public void deleteSingleWorkComment_whenCommentIdIsInvalid() throws Exception {
-        // given
-        doNothing().when(deleteSingleWorkCommentUseCase).deleteSingleWorkComment(any());
-
-        // when
-        ResultActions resultActions = requestDeleteSingleWorkComment("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidContent() {

--- a/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkLikeCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/command/controller/SingleWorkLikeCommandControllerTest.java
@@ -13,6 +13,7 @@ import com.benchpress200.photique.singlework.application.command.port.in.CancelS
 import com.benchpress200.photique.singlework.domain.exception.SingleWorkAlreadyLikedException;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -36,70 +37,78 @@ public class SingleWorkLikeCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private CancelSingleWorkLikeUseCase cancelSingleWorkLikeUseCase;
 
-    @Test
-    @DisplayName("단일작품 좋아요 추가 요청 시 요청이 유효하면 201을 반환한다")
-    void addSingleWorkLike_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+    @Nested
+    @DisplayName("단일작품 좋아요 추가")
+    class AddSingleWorkLikeTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
 
-        // when
-        ResultActions resultActions = requestAddSingleWorkLike("1");
+            // when
+            ResultActions resultActions = requestAddSingleWorkLike("1");
 
-        // then
-        resultActions.andExpect(status().isCreated());
+            // then
+            resultActions.andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("작품 ID가 숫자가 아니면 400을 반환한다")
+        public void whenSingleWorkIdInvalid() throws Exception {
+            // given
+            doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+
+            // when
+            ResultActions resultActions = requestAddSingleWorkLike("invalid");
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("이미 좋아요를 눌렀으면 409를 반환한다")
+        public void whenAlreadyLiked() throws Exception {
+            // given
+            doThrow(new SingleWorkAlreadyLikedException(1L, 1L))
+                    .when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+
+            // when
+            ResultActions resultActions = requestAddSingleWorkLike("1");
+
+            // then
+            resultActions.andExpect(status().isConflict());
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 좋아요 추가 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
-    void addSingleWorkLike_whenSingleWorkIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+    @Nested
+    @DisplayName("단일작품 좋아요 취소")
+    class CancelSingleWorkLikeTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(cancelSingleWorkLikeUseCase).cancelSingleWorkLike(any());
 
-        // when
-        ResultActions resultActions = requestAddSingleWorkLike("invalid");
+            // when
+            ResultActions resultActions = requestCancelSingleWorkLike("1");
 
-        // then
-        resultActions.andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions.andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("단일작품 좋아요 추가 요청 시 이미 좋아요를 눌렀으면 409를 반환한다")
-    void addSingleWorkLike_whenAlreadyLiked() throws Exception {
-        // given
-        doThrow(new SingleWorkAlreadyLikedException(1L, 1L))
-                .when(addSingleWorkLikeUseCase).addSingleWorkLike(any());
+        @Test
+        @DisplayName("작품 ID가 숫자가 아니면 400을 반환한다")
+        public void whenSingleWorkIdInvalid() throws Exception {
+            // given
+            doNothing().when(cancelSingleWorkLikeUseCase).cancelSingleWorkLike(any());
 
-        // when
-        ResultActions resultActions = requestAddSingleWorkLike("1");
+            // when
+            ResultActions resultActions = requestCancelSingleWorkLike("invalid");
 
-        // then
-        resultActions.andExpect(status().isConflict());
-    }
-
-    @Test
-    @DisplayName("단일작품 좋아요 취소 요청 시 요청이 유효하면 204를 반환한다")
-    void cancelSingleWorkLike_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(cancelSingleWorkLikeUseCase).cancelSingleWorkLike(any());
-
-        // when
-        ResultActions resultActions = requestCancelSingleWorkLike("1");
-
-        // then
-        resultActions.andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("단일작품 좋아요 취소 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
-    void cancelSingleWorkLike_whenSingleWorkIdIsInvalid() throws Exception {
-        // given
-        doNothing().when(cancelSingleWorkLikeUseCase).cancelSingleWorkLike(any());
-
-        // when
-        ResultActions resultActions = requestCancelSingleWorkLike("invalid");
-
-        // then
-        resultActions.andExpect(status().isBadRequest());
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestAddSingleWorkLike(String singleWorkId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkCommentQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkCommentQueryControllerTest.java
@@ -11,6 +11,7 @@ import com.benchpress200.photique.singlework.application.query.result.SingleWork
 import com.benchpress200.photique.singlework.application.query.support.fixture.SingleWorkCommentsResultFixture;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -34,65 +35,69 @@ public class SingleWorkCommentQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private GetSingleWorkCommentsUseCase getSingleWorkCommentsUseCase;
 
-    @Test
-    @DisplayName("단일작품 댓글 목록 조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getSingleWorkComments_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+    @Nested
+    @DisplayName("단일작품 댓글 페이지 조회")
+    class GetSingleWorkCommentsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkComments("1", 0, 5);
+            // when
+            ResultActions resultActions = requestGetSingleWorkComments("1", 0, 5);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("단일작품 댓글 목록 조회 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
-    public void getSingleWorkComments_whenSingleWorkIdIsInvalid() throws Exception {
-        // given
-        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+        @Test
+        @DisplayName("작품 ID가 숫자가 아니면 400을 반환한다")
+        public void whenSingleWorkIdInvalid() throws Exception {
+            // given
+            SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkComments("invalid", 0, 5);
+            // when
+            ResultActions resultActions = requestGetSingleWorkComments("invalid", 0, 5);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("단일작품 댓글 목록 조회 요청 시 페이지가 음수이면 400을 반환한다")
-    public void getSingleWorkComments_whenPageIsNegative() throws Exception {
-        // given
-        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+        @Test
+        @DisplayName("페이지 번호가 음수면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkComments("1", -1, 5);
+            // when
+            ResultActions resultActions = requestGetSingleWorkComments("1", -1, 5);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @ValueSource(ints = {0, 11})
-    @DisplayName("단일작품 댓글 목록 조회 요청 시 사이즈가 유효하지 않으면 400을 반환한다")
-    public void getSingleWorkComments_whenSizeIsInvalid(int invalidSize) throws Exception {
-        // given
-        SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
+        @ParameterizedTest
+        @ValueSource(ints = {0, 11})
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        public void whenSizeInvalid(int invalidSize) throws Exception {
+            // given
+            SingleWorkCommentsResult result = SingleWorkCommentsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkCommentsUseCase).getSingleWorkComments(any());
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkComments("1", 0, invalidSize);
+            // when
+            ResultActions resultActions = requestGetSingleWorkComments("1", 0, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestGetSingleWorkComments(

--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkLikeQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkLikeQueryControllerTest.java
@@ -12,6 +12,7 @@ import com.benchpress200.photique.singlework.application.query.support.fixture.L
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,61 +36,65 @@ public class SingleWorkLikeQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchLikedSingleWorkUseCase searchLikedSingleWorkUseCase;
 
-    @Test
-    @DisplayName("좋아요한 단일작품 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchLikedSingleWork_whenRequestIsValid() throws Exception {
-        // given
-        LikedSingleWorkSearchResult result = LikedSingleWorkSearchResultFixture.builder().build();
-        doReturn(result).when(searchLikedSingleWorkUseCase).searchLikedSingleWork(any());
+    @Nested
+    @DisplayName("좋아요한 단일작품 검색")
+    class SearchLikedSingleWorkTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            LikedSingleWorkSearchResult result = LikedSingleWorkSearchResultFixture.builder().build();
+            doReturn(result).when(searchLikedSingleWorkUseCase).searchLikedSingleWork(any());
 
-        // when
-        ResultActions resultActions = requestSearchLikedSingleWork(null, 0, 10);
+            // when
+            ResultActions resultActions = requestSearchLikedSingleWork(null, 0, 10);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @ParameterizedTest
-    @DisplayName("좋아요한 단일작품 검색 요청 시 키워드가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchLikedSingleWork_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkLikeQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchLikedSingleWork(invalidKeyword, 0, 10);
+            // when
+            ResultActions resultActions = requestSearchLikedSingleWork(invalidKeyword, 0, 10);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("좋아요한 단일작품 검색 요청 시 페이지 번호가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidPages")
-    public void searchLikedSingleWork_whenPageIsInvalid(Integer invalidPage) throws Exception {
-        // given
+        @ParameterizedTest
+        @DisplayName("페이지 번호가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkLikeQueryControllerTest#invalidPages")
+        public void whenPageInvalid(Integer invalidPage) throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchLikedSingleWork(null, invalidPage, 10);
+            // when
+            ResultActions resultActions = requestSearchLikedSingleWork(null, invalidPage, 10);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("좋아요한 단일작품 검색 요청 시 페이지 크기가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchLikedSingleWork_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkLikeQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchLikedSingleWork(null, 0, invalidSize);
+            // when
+            ResultActions resultActions = requestSearchLikedSingleWork(null, 0, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywords() {

--- a/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/api/query/controller/SingleWorkQueryControllerTest.java
@@ -10,14 +10,15 @@ import com.benchpress200.photique.singlework.api.query.support.fixture.SingleWor
 import com.benchpress200.photique.singlework.application.query.port.in.GetSingleWorkDetailsUseCase;
 import com.benchpress200.photique.singlework.application.query.port.in.SearchMySingleWorkUseCase;
 import com.benchpress200.photique.singlework.application.query.port.in.SearchSingleWorkUseCase;
-import com.benchpress200.photique.singlework.application.query.result.SingleWorkDetailsResult;
 import com.benchpress200.photique.singlework.application.query.result.MySingleWorkSearchResult;
+import com.benchpress200.photique.singlework.application.query.result.SingleWorkDetailsResult;
 import com.benchpress200.photique.singlework.application.query.result.SingleWorkSearchResult;
 import com.benchpress200.photique.singlework.application.query.support.fixture.MySingleWorkSearchResultFixture;
 import com.benchpress200.photique.singlework.application.query.support.fixture.SingleWorkSearchResultFixture;
 import com.benchpress200.photique.support.base.BaseControllerTest;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -47,159 +48,176 @@ public class SingleWorkQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchMySingleWorkUseCase searchMySingleWorkUseCase;
 
-    @Test
-    @DisplayName("단일작품 상세조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getSingleWorkDetails_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
+    @Nested
+    @DisplayName("단일작품 상세 조회")
+    class GetSingleWorkDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkDetails("1");
+            // when
+            ResultActions resultActions = requestGetSingleWorkDetails("1");
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("작품 ID가 숫자가 아니면 400을 반환한다")
+        public void whenSingleWorkIdInvalid() throws Exception {
+            // given
+            SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
+            doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
+
+            // when
+            ResultActions resultActions = requestGetSingleWorkDetails("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 상세조회 요청 시 작품 ID가 숫자가 아니면 400을 반환한다")
-    public void getSingleWorkDetails_whenSingleWorkIdIsInvalid() throws Exception {
-        // given
-        SingleWorkDetailsResult result = SingleWorkDetailsResultFixture.builder().build();
-        doReturn(result).when(getSingleWorkDetailsUseCase).getSingleWorkDetails(any());
+    @Nested
+    @DisplayName("단일작품 검색")
+    class SearchSingleWorkTest {
 
-        // when
-        ResultActions resultActions = requestGetSingleWorkDetails("invalid");
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWorkSearchResult result = SingleWorkSearchResultFixture.builder().build();
+            doReturn(result).when(searchSingleWorkUseCase).searchSingleWork(any());
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // when
+            ResultActions resultActions = requestSearchSingleWork("work", null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("검색 대상이 유효하지 않으면 400을 반환한다")
+        public void whenTargetInvalid() throws Exception {
+            // given
+            String target = "invalid";
+
+            // when
+            ResultActions resultActions = requestSearchSingleWork(target, null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkQueryControllerTest#invalidKeywordsForSearch")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            String target = "work";
+
+            // when
+            ResultActions resultActions = requestSearchSingleWork(target, invalidKeyword, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            String target = "work";
+
+            // when
+            ResultActions resultActions = requestSearchSingleWork(target, null, -1, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkQueryControllerTest#invalidSizesForSearch")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
+            String target = "work";
+
+            // when
+            ResultActions resultActions = requestSearchSingleWork(target, null, null, invalidSize);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchSingleWork_whenRequestIsValid() throws Exception {
-        // given
-        SingleWorkSearchResult result = SingleWorkSearchResultFixture.builder().build();
-        doReturn(result).when(searchSingleWorkUseCase).searchSingleWork(any());
+    @Nested
+    @DisplayName("내 단일작품 검색")
+    class SearchMySingleWork {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            MySingleWorkSearchResult result = MySingleWorkSearchResultFixture.builder().build();
+            doReturn(result).when(searchMySingleWorkUseCase).searchMySingleWork(any());
 
-        // when
-        ResultActions resultActions = requestSearchSingleWork("work", null, null, null);
+            // when
+            ResultActions resultActions = requestSearchMySingleWork(null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("단일작품 검색 요청 시 검색 대상이 유효하지 않으면 400을 반환한다")
-    public void searchSingleWork_whenTargetIsInvalid() throws Exception {
-        // given
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkQueryControllerTest#invalidKeywordsForMySingleWorkSearch")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchSingleWork("invalid", null, null, null);
+            // when
+            ResultActions resultActions = requestSearchMySingleWork(invalidKeyword, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("단일작품 검색 요청 시 키워드가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywordsForSearch")
-    public void searchSingleWork_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchSingleWork(null, invalidKeyword, null, null);
+            // when
+            ResultActions resultActions = requestSearchMySingleWork(null, -1, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("단일작품 검색 요청 시 페이지 번호가 음수이면 400을 반환한다")
-    public void searchSingleWork_whenPageIsNegative() throws Exception {
-        // given
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.singlework.api.query.controller.SingleWorkQueryControllerTest#invalidSizesForMySingleWorkSearch")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
 
-        // when
-        ResultActions resultActions = requestSearchSingleWork(null, null, -1, null);
+            // when
+            ResultActions resultActions = requestSearchMySingleWork(null, null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("단일작품 검색 요청 시 페이지 크기가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizesForSearch")
-    public void searchSingleWork_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
-
-        // when
-        ResultActions resultActions = requestSearchSingleWork(null, null, null, invalidSize);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("내 단일작품 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchMySingleWork_whenRequestIsValid() throws Exception {
-        // given
-        MySingleWorkSearchResult result = MySingleWorkSearchResultFixture.builder().build();
-        doReturn(result).when(searchMySingleWorkUseCase).searchMySingleWork(any());
-
-        // when
-        ResultActions resultActions = requestSearchMySingleWork(null, null, null);
-
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
-
-    @ParameterizedTest
-    @DisplayName("내 단일작품 검색 요청 시 키워드가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywordsForMySingleWorkSearch")
-    public void searchMySingleWork_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-
-        // when
-        ResultActions resultActions = requestSearchMySingleWork(invalidKeyword, null, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("내 단일작품 검색 요청 시 페이지 번호가 음수이면 400을 반환한다")
-    public void searchMySingleWork_whenPageIsNegative() throws Exception {
-        // given
-
-        // when
-        ResultActions resultActions = requestSearchMySingleWork(null, -1, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("내 단일작품 검색 요청 시 페이지 크기가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizesForMySingleWorkSearch")
-    public void searchMySingleWork_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
-
-        // when
-        ResultActions resultActions = requestSearchMySingleWork(null, null, invalidSize);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywordsForMySingleWorkSearch() {
@@ -233,9 +251,15 @@ public class SingleWorkQueryControllerTest extends BaseControllerTest {
     private ResultActions requestSearchMySingleWork(
             String keyword, Integer page, Integer size) throws Exception {
         MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_MY_DATA);
-        if (keyword != null) builder = builder.param("keyword", keyword);
-        if (page != null) builder = builder.param("page", String.valueOf(page));
-        if (size != null) builder = builder.param("size", String.valueOf(size));
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
         return mockMvc.perform(builder);
     }
 
@@ -248,10 +272,18 @@ public class SingleWorkQueryControllerTest extends BaseControllerTest {
     private ResultActions requestSearchSingleWork(
             String target, String keyword, Integer page, Integer size) throws Exception {
         MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_ROOT);
-        if (target != null) builder = builder.param("target", target);
-        if (keyword != null) builder = builder.param("keyword", keyword);
-        if (page != null) builder = builder.param("page", String.valueOf(page));
-        if (size != null) builder = builder.param("size", String.valueOf(size));
+        if (target != null) {
+            builder = builder.param("target", target);
+        }
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
         return mockMvc.perform(builder);
     }
 }

--- a/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommandServiceTest.java
@@ -38,6 +38,7 @@ import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -83,230 +84,198 @@ public class SingleWorkCommandServiceTest extends BaseServiceTest {
     @Mock
     private OutboxEventPort outboxEventPort;
 
+    @Nested
+    @DisplayName("단일작품 생성")
+    class PostSingleWorkTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            //given
+            SingleWorkCreateCommand command = SingleWorkCreateCommandFixture.builder().build();
+            User user = UserFixture.builder().build();
+            Long userId = user.getId();
+            String imageUrl = "imageUrl";
+            SingleWork singleWork = command.toEntity(user, imageUrl);
+            List<String> tagNames = command.getTags();
+            List<Tag> tags = tagNames.stream()
+                    .map(Tag::of)
+                    .toList();
+            List<SingleWorkTag> singleWorkTags = tags.stream()
+                    .map(tag -> SingleWorkTag.of(singleWork, tag))
+                    .toList();
 
-    @Test
-    @DisplayName("단일작품 생성 처리에 성공한다")
-    public void postSingleWork_WhenCommandIsValid() {
-        //given
-        SingleWorkCreateCommand command = SingleWorkCreateCommandFixture.builder().build();
-        User user = UserFixture.builder().build();
-        Long userId = user.getId();
-        String imageUrl = "imageUrl";
-        SingleWork singleWork = command.toEntity(user, imageUrl);
-        List<String> tagNames = command.getTags();
-        List<Tag> tags = tagNames.stream()
-                .map(Tag::of)
-                .toList();
-        List<SingleWorkTag> singleWorkTags = tags.stream()
-                .map(tag -> SingleWorkTag.of(singleWork, tag))
-                .toList();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
 
-        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+            doReturn(userId).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(imageUrl).when(imageUploaderPort).upload(any(), any());
+            doNothing().when(singleWorkEventPublishPort).publishSingleWorkImageUploadEvent(any());
+            doReturn(singleWork).when(singleWorkCommandPort).save(any());
+            doReturn(tags).when(tagQueryPort).findByNameIn(any());
+            doReturn(tags).when(tagCommandPort).saveAll(any());
+            doReturn(singleWorkTags).when(singleWorkTagCommandPort).saveAll(any());
+            doReturn(outboxEvent).when(outboxEventFactory).singleWorkCreated(any(), any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
 
-        doReturn(userId).when(authenticationUserProviderPort).getCurrentUserId();
-        doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(imageUrl).when(imageUploaderPort).upload(any(), any());
-        doNothing().when(singleWorkEventPublishPort).publishSingleWorkImageUploadEvent(any());
-        doReturn(singleWork).when(singleWorkCommandPort).save(any());
-        doReturn(tags).when(tagQueryPort).findByNameIn(any());
-        doReturn(tags).when(tagCommandPort).saveAll(any());
-        doReturn(singleWorkTags).when(singleWorkTagCommandPort).saveAll(any());
-        doReturn(outboxEvent).when(outboxEventFactory).singleWorkCreated(any(), any());
-        doReturn(outboxEvent).when(outboxEventPort).save(any());
+            //when
+            singleWorkCommandService.postSingleWork(command);
 
-        //when
-        singleWorkCommandService.postSingleWork(command);
+            //then
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(userId);
+            verify(imageUploaderPort).upload(any(), any());
+            verify(singleWorkEventPublishPort).publishSingleWorkImageUploadEvent(any());
+            verify(singleWorkCommandPort).save(any());
+            verify(singleWorkTagCommandPort).saveAll(any());
+            verify(outboxEventFactory).singleWorkCreated(any(), any());
+            verify(outboxEventPort).save(outboxEvent);
+        }
 
-        //then
-        verify(authenticationUserProviderPort).getCurrentUserId();
-        verify(userQueryPort).findByIdAndDeletedAtIsNull(userId);
-        verify(imageUploaderPort).upload(any(), any());
-        verify(singleWorkEventPublishPort).publishSingleWorkImageUploadEvent(any());
-        verify(singleWorkCommandPort).save(any());
-        verify(singleWorkTagCommandPort).saveAll(any());
-        verify(outboxEventFactory).singleWorkCreated(any(), any());
-        verify(outboxEventPort).save(outboxEvent);
+        @Test
+        @DisplayName("작가가 존재하지 않으면 SingleWorkWriterNotFoundException를 던진다")
+        public void whenWriterNotFound() {
+            //given
+            SingleWorkCreateCommand command = SingleWorkCreateCommandFixture.builder().build();
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            //when & then
+            assertThrows(
+                    SingleWorkWriterNotFoundException.class,
+                    () -> singleWorkCommandService.postSingleWork(command)
+            );
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 생성 시 작가가 존재하지 않으면 SingleWorkWriterNotFoundException를 던진다")
-    public void postSingleWork_whenWriterNotFound() {
-        //given
-        SingleWorkCreateCommand command = SingleWorkCreateCommandFixture.builder().build();
+    @Nested
+    @DisplayName("단일작품 수정")
+    class UpdateSingleWorkDetailsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void WhenCommandValid() {
+            //given
+            User writer = UserFixture.builder()
+                    .id(1L)
+                    .build();
+            String imageUrl = "imageUrl";
+            SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+            SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+            SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+            List<SingleWorkTag> singleWorkTags = List.of();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
 
-        doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
-        doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(singleWorkTags).when(singleWorkTagQueryPort).findBySingleWorkWithTag(any());
+            doReturn(outboxEvent).when(outboxEventFactory).singleWorkUpdated(any(), any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
 
-        //when & then
-        assertThrows(
-                SingleWorkWriterNotFoundException.class,
-                () -> singleWorkCommandService.postSingleWork(command)
-        );
+            //when
+            singleWorkCommandService.updateSingleWorkDetails(command);
+
+            //then
+            verify(singleWorkQueryPort).findByIdAndDeletedAtIsNull(command.getSingleWorkId());
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(singleWorkTagQueryPort).findBySingleWorkWithTag(singleWork);
+            verify(outboxEventFactory).singleWorkUpdated(any(), any());
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("작품이 존재하지 않으면 SingleWorkNotFoundException를 던진다")
+        public void whenSingleWorkNotFound() {
+            //given
+            SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            //when & then
+            assertThrows(
+                    SingleWorkNotFoundException.class,
+                    () -> singleWorkCommandService.updateSingleWorkDetails(command)
+            );
+        }
+
+        @Test
+        @DisplayName("작품의 소유자가 아니면 SingleWorkNotOwnedException를 던진다")
+        public void whenNotOwner() {
+            //given
+            User writer = UserFixture.builder().id(1L).build();
+            String imageUrl = "imageUrl";
+            SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+            SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+            SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
+
+            //when & then
+            assertThrows(
+                    SingleWorkNotOwnedException.class,
+                    () -> singleWorkCommandService.updateSingleWorkDetails(command)
+            );
+        }
     }
 
-    @Test
-    @DisplayName("단일작품 수정 처리에 성공한다")
-    public void updateSingleWorkDetails_WhenCommandIsValid() {
-        //given
-        User writer = UserFixture.builder()
-                .id(1L)
-                .build();
-        String imageUrl = "imageUrl";
-        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
-        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
-        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
-        List<SingleWorkTag> singleWorkTags = List.of();
-        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+    @Nested
+    @DisplayName("단일작품 삭제")
+    class DeleteSingleWork {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            //given
+            User writer = UserFixture.builder()
+                    .id(1L)
+                    .build();
+            String imageUrl = "imageUrl";
+            SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+            SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
 
-        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
-        doReturn(singleWorkTags).when(singleWorkTagQueryPort).findBySingleWorkWithTag(any());
-        doReturn(outboxEvent).when(outboxEventFactory).singleWorkUpdated(any(), any());
-        doReturn(outboxEvent).when(outboxEventPort).save(any());
+            doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(outboxEvent).when(outboxEventFactory).singleWorkDeleted(any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
 
-        //when
-        singleWorkCommandService.updateSingleWorkDetails(command);
+            //when
+            singleWorkCommandService.deleteSingleWork(1L);
 
-        //then
-        verify(singleWorkQueryPort).findByIdAndDeletedAtIsNull(command.getSingleWorkId());
-        verify(authenticationUserProviderPort).getCurrentUserId();
-        verify(singleWorkTagQueryPort).findBySingleWorkWithTag(singleWork);
-        verify(outboxEventFactory).singleWorkUpdated(any(), any());
-        verify(outboxEventPort).save(outboxEvent);
-    }
+            //then
+            verify(outboxEventFactory).singleWorkDeleted(singleWork);
+            verify(outboxEventPort).save(outboxEvent);
+        }
 
-    @Test
-    @DisplayName("태그 업데이트가 포함된 단일작품 수정 처리에 성공한다")
-    public void updateSingleWorkDetails_WhenCommandIncludesTagUpdate() {
-        //given
-        User writer = UserFixture.builder()
-                .id(1L)
-                .build();
-        String imageUrl = "imageUrl";
-        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
-        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
-        List<String> tagNames = List.of("tag1", "tag2");
-        List<Tag> tags = tagNames.stream()
-                .map(Tag::of)
-                .toList();
-        List<SingleWorkTag> singleWorkTags = tags.stream()
-                .map(tag -> SingleWorkTag.of(singleWork, tag))
-                .toList();
-        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder()
-                .updateTags(true)
-                .tags(tagNames)
-                .build();
-        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+        @Test
+        @DisplayName("작품이 존재하지 않으면 아무 처리도 하지 않는다")
+        public void whenSingleWorkNotFound() {
+            //given
+            doReturn(Optional.empty()).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
 
-        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
-        doNothing().when(singleWorkTagCommandPort).deleteBySingleWork(any());
-        doReturn(tags).when(tagQueryPort).findByNameIn(any());
-        doReturn(tags).when(tagCommandPort).saveAll(any());
-        doReturn(singleWorkTags).when(singleWorkTagCommandPort).saveAll(any());
-        doReturn(singleWorkTags).when(singleWorkTagQueryPort).findBySingleWorkWithTag(any());
-        doReturn(outboxEvent).when(outboxEventFactory).singleWorkUpdated(any(), any());
-        doReturn(outboxEvent).when(outboxEventPort).save(any());
+            //when
+            singleWorkCommandService.deleteSingleWork(1L);
 
-        //when
-        singleWorkCommandService.updateSingleWorkDetails(command);
+            //then
+            verify(outboxEventPort, never()).save(any());
+        }
 
-        //then
-        verify(singleWorkTagCommandPort).deleteBySingleWork(singleWork);
-        verify(singleWorkTagCommandPort).saveAll(any());
-        verify(outboxEventFactory).singleWorkUpdated(any(), any());
-        verify(outboxEventPort).save(outboxEvent);
-    }
+        @Test
+        @DisplayName("작품의 소유자가 아니면 SingleWorkNotOwnedException를 던진다")
+        public void whenNotOwner() {
+            //given
+            User writer = UserFixture.builder().id(1L).build();
+            String imageUrl = "imageUrl";
+            SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
+            SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
 
-    @Test
-    @DisplayName("단일작품 수정 시 작품이 존재하지 않으면 SingleWorkNotFoundException를 던진다")
-    public void updateSingleWorkDetails_WhenSingleWorkNotFound() {
-        //given
-        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
+            doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
 
-        doReturn(Optional.empty()).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-
-        //when & then
-        assertThrows(
-                SingleWorkNotFoundException.class,
-                () -> singleWorkCommandService.updateSingleWorkDetails(command)
-        );
-    }
-
-    @Test
-    @DisplayName("단일작품 수정 시 작품의 소유자가 아니면 SingleWorkNotOwnedException를 던진다")
-    public void updateSingleWorkDetails_WhenNotOwner() {
-        //given
-        User writer = UserFixture.builder().id(1L).build();
-        String imageUrl = "imageUrl";
-        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
-        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
-        SingleWorkUpdateCommand command = SingleWorkUpdateCommandFixture.builder().build();
-
-        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
-
-        //when & then
-        assertThrows(
-                SingleWorkNotOwnedException.class,
-                () -> singleWorkCommandService.updateSingleWorkDetails(command)
-        );
-    }
-
-    @Test
-    @DisplayName("단일작품 삭제 처리에 성공한다")
-    public void deleteSingleWork_whenSingleWorkExists() {
-        //given
-        User writer = UserFixture.builder()
-                .id(1L)
-                .build();
-        String imageUrl = "imageUrl";
-        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
-        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
-        OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
-
-        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
-        doReturn(outboxEvent).when(outboxEventFactory).singleWorkDeleted(any());
-        doReturn(outboxEvent).when(outboxEventPort).save(any());
-
-        //when
-        singleWorkCommandService.deleteSingleWork(1L);
-
-        //then
-        verify(outboxEventFactory).singleWorkDeleted(singleWork);
-        verify(outboxEventPort).save(outboxEvent);
-    }
-
-    @Test
-    @DisplayName("단일작품 삭제 시 작품이 존재하지 않으면 아무 처리도 하지 않는다")
-    public void deleteSingleWork_whenSingleWorkNotFound() {
-        //given
-        doReturn(Optional.empty()).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-
-        //when
-        singleWorkCommandService.deleteSingleWork(1L);
-
-        //then
-        verify(outboxEventPort, never()).save(any());
-    }
-
-    @Test
-    @DisplayName("단일작품 삭제 시 작품의 소유자가 아니면 SingleWorkNotOwnedException를 던진다")
-    public void deleteSingleWork_whenNotOwner() {
-        //given
-        User writer = UserFixture.builder().id(1L).build();
-        String imageUrl = "imageUrl";
-        SingleWorkCreateCommand createCommand = SingleWorkCreateCommandFixture.builder().build();
-        SingleWork singleWork = createCommand.toEntity(writer, imageUrl);
-
-        doReturn(Optional.of(singleWork)).when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-        doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
-
-        //when & then
-        assertThrows(
-                SingleWorkNotOwnedException.class,
-                () -> singleWorkCommandService.deleteSingleWork(1L)
-        );
+            //when & then
+            assertThrows(
+                    SingleWorkNotOwnedException.class,
+                    () -> singleWorkCommandService.deleteSingleWork(1L)
+            );
+        }
     }
 }

--- a/src/test/java/com/benchpress200/photique/user/api/command/controller/FollowCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/user/api/command/controller/FollowCommandControllerTest.java
@@ -11,6 +11,7 @@ import com.benchpress200.photique.support.base.BaseControllerTest;
 import com.benchpress200.photique.user.application.command.port.in.FollowUseCase;
 import com.benchpress200.photique.user.application.command.port.in.UnfollowUseCase;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
@@ -34,60 +35,68 @@ public class FollowCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private UnfollowUseCase unfollowUseCase;
 
-    @Test
-    @DisplayName("팔로우 요청 시 요청이 유효하면 201을 반환한다")
-    public void follow_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(followUseCase).follow(any());
+    @Nested
+    @DisplayName("팔로우")
+    class FollowTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(followUseCase).follow(any());
 
-        // when
-        ResultActions resultActions = requestFollow("1");
+            // when
+            ResultActions resultActions = requestFollow("1");
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("followeeId가 숫자가 아니면 400을 반환한다")
+        public void whenFolloweeIdInvalid() throws Exception {
+            // given
+            doNothing().when(followUseCase).follow(any());
+
+            // when
+            ResultActions resultActions = requestFollow("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("팔로우 요청 시 followeeId가 숫자가 아니면 400을 반환한다")
-    public void follow_whenFolloweeIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(followUseCase).follow(any());
+    @Nested
+    @DisplayName("언팔로우")
+    class UnfollowTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(unfollowUseCase).unfollow(any());
 
-        // when
-        ResultActions resultActions = requestFollow("invalid");
+            // when
+            ResultActions resultActions = requestUnfollow("1");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("팔로우 취소 요청 시 요청이 유효하면 204를 반환한다")
-    public void unfollow_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(unfollowUseCase).unfollow(any());
+        @Test
+        @DisplayName("followeeId가 숫자가 아니면 400을 반환한다")
+        public void whenFolloweeIdInvalid() throws Exception {
+            // given
+            doNothing().when(unfollowUseCase).unfollow(any());
 
-        // when
-        ResultActions resultActions = requestUnfollow("1");
+            // when
+            ResultActions resultActions = requestUnfollow("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("팔로우 취소 요청 시 followeeId가 숫자가 아니면 400을 반환한다")
-    public void unfollow_whenFolloweeIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(unfollowUseCase).unfollow(any());
-
-        // when
-        ResultActions resultActions = requestUnfollow("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private ResultActions requestFollow(String followeeId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/user/api/command/controller/UserCommandControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/user/api/command/controller/UserCommandControllerTest.java
@@ -23,6 +23,7 @@ import com.benchpress200.photique.user.application.command.port.in.UpdateUserPas
 import com.benchpress200.photique.user.application.command.port.in.WithdrawUseCase;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -61,347 +62,368 @@ public class UserCommandControllerTest extends BaseControllerTest {
     @MockitoBean
     private WithdrawUseCase withdrawUseCase;
 
-    @Test
-    @DisplayName("회원가입 요청 시 요청이 유효하면 201을 반환한다")
-    public void register_whenRequestIsValid() throws Exception {
-        // given
-        ResisterRequestFixture request = ResisterRequestFixture.builder().build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(resisterUseCase).resister(any());
+    @Nested
+    @DisplayName("회원가입")
+    class RegisterTest {
+        @Test
+        @DisplayName("요청이 유효하면 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            ResisterRequestFixture request = ResisterRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(resisterUseCase).resister(any());
 
-        // when
-        ResultActions resultActions = requestRegister(userPart, null);
+            // when
+            ResultActions resultActions = requestRegister(userPart, null);
 
-        // then
-        resultActions
-                .andExpect(status().isCreated());
+            // then
+            resultActions
+                    .andExpect(status().isCreated());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이메일이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidEmails")
+        public void whenEmailInvalid(String invalidEmail) throws Exception {
+            // given
+            ResisterRequestFixture request = ResisterRequestFixture.builder()
+                    .email(invalidEmail)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(resisterUseCase).resister(any());
+
+            // when
+            ResultActions resultActions = requestRegister(userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("비밀번호가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidPasswords")
+        public void whenPasswordInvalid(String invalidPassword) throws Exception {
+            // given
+            ResisterRequestFixture request = ResisterRequestFixture.builder()
+                    .password(invalidPassword)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(resisterUseCase).resister(any());
+
+            // when
+            ResultActions resultActions = requestRegister(userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidNicknames")
+        public void whenNicknameInvalid(String invalidNickname) throws Exception {
+            // given
+            ResisterRequestFixture request = ResisterRequestFixture.builder()
+                    .nickname(invalidNickname)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(resisterUseCase).resister(any());
+
+            // when
+            ResultActions resultActions = requestRegister(userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("프로필 사진이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidProfileImages")
+        public void register_whenProfileImageIsInvalid(MockMultipartFile invalidProfileImage) throws Exception {
+            // given
+            ResisterRequestFixture request = ResisterRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(resisterUseCase).resister(any());
+
+            // when
+            ResultActions resultActions = requestRegister(userPart, invalidProfileImage);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("회원가입 요청 시 email이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidEmails")
-    public void register_whenEmailIsInvalid(String invalidEmail) throws Exception {
-        // given
-        ResisterRequestFixture request = ResisterRequestFixture.builder()
-                .email(invalidEmail)
-                .build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(resisterUseCase).resister(any());
+    @Nested
+    @DisplayName("유저 정보 수정")
+    class UpdateUserDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
 
-        // when
-        ResultActions resultActions = requestRegister(userPart, null);
+            // when
+            ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetails("invalid", userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidNicknamesForUpdate")
+        public void whenNicknameInvalid(String invalidNickname) throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
+                    .nickname(invalidNickname)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("소개가 유효하지 않으면 400을 반환한다")
+        public void whenIntroductionInvalid() throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
+                    .introduction("a".repeat(51))
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("프로필 사진이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidProfileImagesForUpdate")
+        public void whenProfileImageInvalid(MockMultipartFile invalidProfileImage)
+                throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+            doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetails("1", userPart, invalidProfileImage);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("회원가입 요청 시 password가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidPasswords")
-    public void register_whenPasswordIsInvalid(String invalidPassword) throws Exception {
-        // given
-        ResisterRequestFixture request = ResisterRequestFixture.builder()
-                .password(invalidPassword)
-                .build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(resisterUseCase).resister(any());
+    @Nested
+    @DisplayName("유저 비밀번호 수정")
+    class UpdateUserPasswordTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder().build();
+            doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
 
-        // when
-        ResultActions resultActions = requestRegister(userPart, null);
+            // when
+            ResultActions resultActions = requestUpdateUserPassword("1", request);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder().build();
+            doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserPassword("invalid", request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("비밀번호가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidPasswords")
+        public void whenPasswordInvalid(String invalidPassword) throws Exception {
+            // given
+            UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder()
+                    .password(invalidPassword)
+                    .build();
+            doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
+
+            // when
+            ResultActions resultActions = requestUpdateUserPassword("1", request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("회원가입 요청 시 nickname이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidNicknames")
-    public void register_whenNicknameIsInvalid(String invalidNickname) throws Exception {
-        // given
-        ResisterRequestFixture request = ResisterRequestFixture.builder()
-                .nickname(invalidNickname)
-                .build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(resisterUseCase).resister(any());
+    @Nested
+    @DisplayName("유저 비밀번호 초기화")
+    class ResetUserPasswordTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder().build();
+            doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
 
-        // when
-        ResultActions resultActions = requestRegister(userPart, null);
+            // when
+            ResultActions resultActions = requestResetUserPassword(request);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
+
+        @ParameterizedTest
+        @DisplayName("이메일이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidEmails")
+        public void whenEmailInvalid(String invalidEmail) throws Exception {
+            // given
+            UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder()
+                    .email(invalidEmail)
+                    .build();
+            doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
+
+            // when
+            ResultActions resultActions = requestResetUserPassword(request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("비밀번호가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.command.controller.UserCommandControllerTest#invalidPasswords")
+        public void whenPasswordInvalid(String invalidPassword) throws Exception {
+            // given
+            UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder()
+                    .password(invalidPassword)
+                    .build();
+            doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
+
+            // when
+            ResultActions resultActions = requestResetUserPassword(request);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("회원가입 요청 시 profileImage가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidProfileImages")
-    public void register_whenProfileImageIsInvalid(MockMultipartFile invalidProfileImage) throws Exception {
-        // given
-        ResisterRequestFixture request = ResisterRequestFixture.builder().build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(resisterUseCase).resister(any());
+    @Nested
+    @DisplayName("회원탈퇴")
+    class WithdrawTest {
+        @Test
+        @DisplayName("요청이 유효하면 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doNothing().when(withdrawUseCase).withdraw(any());
 
-        // when
-        ResultActions resultActions = requestRegister(userPart, invalidProfileImage);
+            // when
+            ResultActions resultActions = requestWithdraw("1");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isNoContent());
+        }
 
-    @Test
-    @DisplayName("유저 정보 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateUserDetails_whenRequestIsValid() throws Exception {
-        // given
-        UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            doNothing().when(withdrawUseCase).withdraw(any());
 
-        // when
-        ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
+            // when
+            ResultActions resultActions = requestWithdraw("invalid");
 
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("유저 정보 수정 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void updateUserDetails_whenUserIdIsNotNumber() throws Exception {
-        // given
-        UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserDetails("invalid", userPart, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 정보 수정 요청 시 nickname이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidNicknamesForUpdate")
-    public void updateUserDetails_whenNicknameIsInvalid(String invalidNickname) throws Exception {
-        // given
-        UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
-                .nickname(invalidNickname)
-                .build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("유저 정보 수정 요청 시 introduction이 유효하지 않으면 400을 반환한다")
-    public void updateUserDetails_whenIntroductionIsInvalid() throws Exception {
-        // given
-        UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
-                .introduction("a".repeat(51))
-                .build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserDetails("1", userPart, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 정보 수정 요청 시 profileImage가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidProfileImagesForUpdate")
-    public void updateUserDetails_whenProfileImageIsInvalid(MockMultipartFile invalidProfileImage) throws Exception {
-        // given
-        UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
-        MockMultipartFile userPart = MultipartJsonFixture.builder()
-                .key(MultipartKey.USER)
-                .object(request)
-                .objectMapper(objectMapper)
-                .build();
-        doNothing().when(updateUserDetailsUseCase).updateUserDetails(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserDetails("1", userPart, invalidProfileImage);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("유저 비밀번호 수정 요청 시 요청이 유효하면 204를 반환한다")
-    public void updateUserPassword_whenRequestIsValid() throws Exception {
-        // given
-        UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder().build();
-        doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserPassword("1", request);
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("유저 비밀번호 수정 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void updateUserPassword_whenUserIdIsNotNumber() throws Exception {
-        // given
-        UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder().build();
-        doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserPassword("invalid", request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 비밀번호 수정 요청 시 password가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidPasswords")
-    public void updateUserPassword_whenPasswordIsInvalid(String invalidPassword) throws Exception {
-        // given
-        UserPasswordUpdateRequestFixture request = UserPasswordUpdateRequestFixture.builder()
-                .password(invalidPassword)
-                .build();
-        doNothing().when(updateUserPasswordUseCase).updateUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestUpdateUserPassword("1", request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("유저 비밀번호 초기화 요청 시 요청이 유효하면 204를 반환한다")
-    public void resetUserPassword_whenRequestIsValid() throws Exception {
-        // given
-        UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder().build();
-        doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestResetUserPassword(request);
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 비밀번호 초기화 요청 시 email이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidEmails")
-    public void resetUserPassword_whenEmailIsInvalid(String invalidEmail) throws Exception {
-        // given
-        UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder()
-                .email(invalidEmail)
-                .build();
-        doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestResetUserPassword(request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 비밀번호 초기화 요청 시 password가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidPasswords")
-    public void resetUserPassword_whenPasswordIsInvalid(String invalidPassword) throws Exception {
-        // given
-        UserPasswordResetRequestFixture request = UserPasswordResetRequestFixture.builder()
-                .password(invalidPassword)
-                .build();
-        doNothing().when(resetUserPasswordUseCase).resetUserPassword(any());
-
-        // when
-        ResultActions resultActions = requestResetUserPassword(request);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("회원탈퇴 요청 시 요청이 유효하면 204를 반환한다")
-    public void withdraw_whenRequestIsValid() throws Exception {
-        // given
-        doNothing().when(withdrawUseCase).withdraw(any());
-
-        // when
-        ResultActions resultActions = requestWithdraw("1");
-
-        // then
-        resultActions
-                .andExpect(status().isNoContent());
-    }
-
-    @Test
-    @DisplayName("회원탈퇴 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void withdraw_whenUserIdIsNotNumber() throws Exception {
-        // given
-        doNothing().when(withdrawUseCase).withdraw(any());
-
-        // when
-        ResultActions resultActions = requestWithdraw("invalid");
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidEmails() {

--- a/src/test/java/com/benchpress200/photique/user/api/query/controller/FollowQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/user/api/query/controller/FollowQueryControllerTest.java
@@ -13,6 +13,7 @@ import com.benchpress200.photique.user.application.query.result.FolloweeSearchRe
 import com.benchpress200.photique.user.application.query.result.FollowerSearchResult;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -39,126 +40,134 @@ public class FollowQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchFolloweeUseCase searchFolloweeUseCase;
 
-    @Test
-    @DisplayName("팔로워 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchFollower_whenRequestIsValid() throws Exception {
-        // given
-        FollowerSearchResult result = FollowerSearchResult.builder().build();
-        doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+    @Nested
+    @DisplayName("팔로워 검색")
+    class SearchFollowerTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            FollowerSearchResult result = FollowerSearchResult.builder().build();
+            doReturn(result).when(searchFollowerUseCase).searchFollower(any());
 
-        // when
-        ResultActions resultActions = requestSearchFollower("1", null, null, null);
+            // when
+            ResultActions resultActions = requestSearchFollower("1", null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            FollowerSearchResult result = FollowerSearchResult.builder().build();
+            doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+
+            // when
+            ResultActions resultActions = requestSearchFollower("invalid", null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            FollowerSearchResult result = FollowerSearchResult.builder().build();
+            doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+
+            // when
+            ResultActions resultActions = requestSearchFollower("1", null, -1, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.query.controller.FollowQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
+            FollowerSearchResult result = FollowerSearchResult.builder().build();
+            doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+
+            // when
+            ResultActions resultActions = requestSearchFollower("1", null, null, invalidSize);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("팔로워 검색 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void searchFollower_whenUserIdIsNotNumber() throws Exception {
-        // given
-        FollowerSearchResult result = FollowerSearchResult.builder().build();
-        doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+    @Nested
+    @DisplayName("팔로이 검색")
+    class SearchFolloweeTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            FolloweeSearchResult result = FolloweeSearchResult.builder().build();
+            doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
 
-        // when
-        ResultActions resultActions = requestSearchFollower("invalid", null, null, null);
+            // when
+            ResultActions resultActions = requestSearchFollowee("1", null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("팔로워 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchFollower_whenPageIsNegative() throws Exception {
-        // given
-        FollowerSearchResult result = FollowerSearchResult.builder().build();
-        doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            FolloweeSearchResult result = FolloweeSearchResult.builder().build();
+            doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
 
-        // when
-        ResultActions resultActions = requestSearchFollower("1", null, -1, null);
+            // when
+            ResultActions resultActions = requestSearchFollowee("invalid", null, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("팔로워 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchFollower_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
-        FollowerSearchResult result = FollowerSearchResult.builder().build();
-        doReturn(result).when(searchFollowerUseCase).searchFollower(any());
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            FolloweeSearchResult result = FolloweeSearchResult.builder().build();
+            doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
 
-        // when
-        ResultActions resultActions = requestSearchFollower("1", null, null, invalidSize);
+            // when
+            ResultActions resultActions = requestSearchFollowee("1", null, -1, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("팔로이 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchFollowee_whenRequestIsValid() throws Exception {
-        // given
-        FolloweeSearchResult result = FolloweeSearchResult.builder().build();
-        doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.query.controller.FollowQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
+            FolloweeSearchResult result = FolloweeSearchResult.builder().build();
+            doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
 
-        // when
-        ResultActions resultActions = requestSearchFollowee("1", null, null, null);
+            // when
+            ResultActions resultActions = requestSearchFollowee("1", null, null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("팔로이 검색 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void searchFollowee_whenUserIdIsNotNumber() throws Exception {
-        // given
-        FolloweeSearchResult result = FolloweeSearchResult.builder().build();
-        doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
-
-        // when
-        ResultActions resultActions = requestSearchFollowee("invalid", null, null, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("팔로이 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchFollowee_whenPageIsNegative() throws Exception {
-        // given
-        FolloweeSearchResult result = FolloweeSearchResult.builder().build();
-        doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
-
-        // when
-        ResultActions resultActions = requestSearchFollowee("1", null, -1, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("팔로이 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchFollowee_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
-        FolloweeSearchResult result = FolloweeSearchResult.builder().build();
-        doReturn(result).when(searchFolloweeUseCase).searchFollowee(any());
-
-        // when
-        ResultActions resultActions = requestSearchFollowee("1", null, null, invalidSize);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<Integer> invalidSizes() {

--- a/src/test/java/com/benchpress200/photique/user/api/query/controller/UserQueryControllerTest.java
+++ b/src/test/java/com/benchpress200/photique/user/api/query/controller/UserQueryControllerTest.java
@@ -17,6 +17,7 @@ import com.benchpress200.photique.user.application.query.result.UserDetailsResul
 import com.benchpress200.photique.user.application.query.result.UserSearchResult;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,140 +50,156 @@ public class UserQueryControllerTest extends BaseControllerTest {
     @MockitoBean
     private SearchUserUseCase searchUserUseCase;
 
-    @Test
-    @DisplayName("닉네임 중복 검사 요청 시 요청이 유효하면 200을 반환한다")
-    public void validateNickname_whenRequestIsValid() throws Exception {
-        // given
-        doReturn(NicknameValidateResult.of(false)).when(validateNicknameUseCase).validateNickname(any());
+    @Nested
+    @DisplayName("닉네임 중복 검사")
+    class ValidateNicknameTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            doReturn(NicknameValidateResult.of(false)).when(validateNicknameUseCase).validateNickname(any());
 
-        // when
-        ResultActions resultActions = requestValidateNickname("테스트닉");
+            // when
+            ResultActions resultActions = requestValidateNickname("테스트닉");
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @ParameterizedTest
+        @DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.query.controller.UserQueryControllerTest#invalidNicknames")
+        public void whenNicknameInvalid(String invalidNickname) throws Exception {
+            // given
+            doReturn(NicknameValidateResult.of(false)).when(validateNicknameUseCase).validateNickname(any());
+
+            // when
+            ResultActions resultActions = requestValidateNickname(invalidNickname);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @ParameterizedTest
-    @DisplayName("닉네임 중복 검사 요청 시 nickname이 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidNicknames")
-    public void validateNickname_whenNicknameIsInvalid(String invalidNickname) throws Exception {
-        // given
-        doReturn(NicknameValidateResult.of(false)).when(validateNicknameUseCase).validateNickname(any());
+    @Nested
+    @DisplayName("유저 정보 상세 조회")
+    class GetUserDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserDetailsResult result = UserDetailsResult.builder().build();
+            doReturn(result).when(getUserDetailsUseCase).getUserDetails(any());
 
-        // when
-        ResultActions resultActions = requestValidateNickname(invalidNickname);
+            // when
+            ResultActions resultActions = requestGetUserDetails("1");
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("userId가 숫자가 아니면 400을 반환한다")
+        public void whenUserIdInvalid() throws Exception {
+            // given
+            UserDetailsResult result = UserDetailsResult.builder().build();
+            doReturn(result).when(getUserDetailsUseCase).getUserDetails(any());
+
+            // when
+            ResultActions resultActions = requestGetUserDetails("invalid");
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("유저 정보 상세 조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getUserDetails_whenRequestIsValid() throws Exception {
-        // given
-        UserDetailsResult result = UserDetailsResult.builder().build();
-        doReturn(result).when(getUserDetailsUseCase).getUserDetails(any());
+    @Nested
+    @DisplayName("내 정보 상세 조회")
+    class GetMyDetailsTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            MyDetailsResult result = MyDetailsResult.builder().build();
+            doReturn(result).when(getMyDetailsUseCase).getMyDetails();
 
-        // when
-        ResultActions resultActions = requestGetUserDetails("1");
+            // when
+            ResultActions resultActions = requestGetMyDetails();
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
     }
 
-    @Test
-    @DisplayName("유저 정보 상세 조회 요청 시 userId가 숫자가 아니면 400을 반환한다")
-    public void getUserDetails_whenUserIdIsNotNumber() throws Exception {
-        // given
-        UserDetailsResult result = UserDetailsResult.builder().build();
-        doReturn(result).when(getUserDetailsUseCase).getUserDetails(any());
+    @Nested
+    @DisplayName("유저 검색")
+    class ResisterTest {
+        @Test
+        @DisplayName("요청이 유효하면 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserSearchResult result = UserSearchResult.builder().build();
+            doReturn(result).when(searchUserUseCase).searchUser(any());
 
-        // when
-        ResultActions resultActions = requestGetUserDetails("invalid");
+            // when
+            ResultActions resultActions = requestSearchUser("테스트닉", null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isOk());
+        }
 
-    @Test
-    @DisplayName("내 정보 조회 요청 시 요청이 유효하면 200을 반환한다")
-    public void getMyDetails_whenRequestIsValid() throws Exception {
-        // given
-        MyDetailsResult result = MyDetailsResult.builder().build();
-        doReturn(result).when(getMyDetailsUseCase).getMyDetails();
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.query.controller.UserQueryControllerTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            UserSearchResult result = UserSearchResult.builder().build();
+            doReturn(result).when(searchUserUseCase).searchUser(any());
 
-        // when
-        ResultActions resultActions = requestGetMyDetails();
+            // when
+            ResultActions resultActions = requestSearchUser(invalidKeyword, null, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("유저 검색 요청 시 요청이 유효하면 200을 반환한다")
-    public void searchUser_whenRequestIsValid() throws Exception {
-        // given
-        UserSearchResult result = UserSearchResult.builder().build();
-        doReturn(result).when(searchUserUseCase).searchUser(any());
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            UserSearchResult result = UserSearchResult.builder().build();
+            doReturn(result).when(searchUserUseCase).searchUser(any());
 
-        // when
-        ResultActions resultActions = requestSearchUser("테스트닉", null, null);
+            // when
+            ResultActions resultActions = requestSearchUser("테스트닉", -1, null);
 
-        // then
-        resultActions
-                .andExpect(status().isOk());
-    }
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
 
-    @ParameterizedTest
-    @DisplayName("유저 검색 요청 시 keyword가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidKeywords")
-    public void searchUser_whenKeywordIsInvalid(String invalidKeyword) throws Exception {
-        // given
-        UserSearchResult result = UserSearchResult.builder().build();
-        doReturn(result).when(searchUserUseCase).searchUser(any());
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.user.api.query.controller.UserQueryControllerTest#invalidSizes")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
+            UserSearchResult result = UserSearchResult.builder().build();
+            doReturn(result).when(searchUserUseCase).searchUser(any());
 
-        // when
-        ResultActions resultActions = requestSearchUser(invalidKeyword, null, null);
+            // when
+            ResultActions resultActions = requestSearchUser("테스트닉", null, invalidSize);
 
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("유저 검색 요청 시 page가 음수이면 400을 반환한다")
-    public void searchUser_whenPageIsNegative() throws Exception {
-        // given
-        UserSearchResult result = UserSearchResult.builder().build();
-        doReturn(result).when(searchUserUseCase).searchUser(any());
-
-        // when
-        ResultActions resultActions = requestSearchUser("테스트닉", -1, null);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
-    }
-
-    @ParameterizedTest
-    @DisplayName("유저 검색 요청 시 size가 유효하지 않으면 400을 반환한다")
-    @MethodSource("invalidSizes")
-    public void searchUser_whenSizeIsInvalid(Integer invalidSize) throws Exception {
-        // given
-        UserSearchResult result = UserSearchResult.builder().build();
-        doReturn(result).when(searchUserUseCase).searchUser(any());
-
-        // when
-        ResultActions resultActions = requestSearchUser("테스트닉", null, invalidSize);
-
-        // then
-        resultActions
-                .andExpect(status().isBadRequest());
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     private static Stream<String> invalidKeywords() {


### PR DESCRIPTION
# 목적
각 테스트 클래스의 내용이 방대하여 가독성을 향상시킬 필요성을 느꼈습니다.

# 작업 내용
Nested로 뎁스를 넣어서 테스트 대상 메서드별로 구분하는 작업을 진행했습니다.