### PR TITLE
test(auth): 인증 메일 코드 검증 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/auth/application/command/AuthCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/auth/application/command/AuthCommandServiceTest.java
@@ -1,0 +1,116 @@
+package com.benchpress200.photique.auth.application.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.benchpress200.photique.auth.application.command.model.AuthMailCodeValidateCommand;
+import com.benchpress200.photique.auth.application.command.port.out.mail.MailSenderPort;
+import com.benchpress200.photique.auth.application.command.port.out.persistence.AuthMailCodeCommandPort;
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
+import com.benchpress200.photique.auth.application.command.result.AuthMailCodeValidateResult;
+import com.benchpress200.photique.auth.application.command.service.AuthCommandService;
+import com.benchpress200.photique.auth.application.query.port.out.persistence.AuthMailCodeQueryPort;
+import com.benchpress200.photique.auth.application.support.fixture.AuthMailCodeValidateCommandFixture;
+import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
+import com.benchpress200.photique.auth.domain.exception.VerificationCodeNotFoundException;
+import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
+import com.benchpress200.photique.support.base.BaseServiceTest;
+import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("인증 커맨드 서비스 테스트")
+public class AuthCommandServiceTest extends BaseServiceTest {
+    @InjectMocks
+    private AuthCommandService authCommandService;
+
+    @Mock
+    private AuthMailCodeCommandPort authMailCodeCommandPort;
+
+    @Mock
+    private AuthMailCodeQueryPort authMailCodeQueryPort;
+
+    @Mock
+    private MailSenderPort mailSenderPort;
+
+    @Mock
+    private UserQueryPort userQueryPort;
+
+    @Mock
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    @Nested
+    @DisplayName("인증 메일 코드 검증")
+    class ValidateAuthMailCodeTest {
+        @Test
+        @DisplayName("코드가 일치하면 검증 성공 결과를 반환하고 인증 상태를 저장한다")
+        public void whenCodeValid() {
+            // given
+            AuthMailCode authMailCode = AuthMailCodeFixture.builder()
+                    .code("123456")
+                    .build();
+
+            AuthMailCodeValidateCommand command = AuthMailCodeValidateCommandFixture.builder()
+                    .email(authMailCode.getEmail())
+                    .code("123456")
+                    .build();
+
+            doReturn(Optional.of(authMailCode)).when(authMailCodeQueryPort).findById(any());
+
+            // when
+            AuthMailCodeValidateResult result = authCommandService.validateAuthMailCode(command);
+
+            // then
+            verify(authMailCodeQueryPort).findById(command.getEmail());
+            verify(authMailCodeCommandPort).save(authMailCode);
+            assertThat(result.isSuccess()).isTrue();
+        }
+
+        @Test
+        @DisplayName("코드가 일치하지 않으면 검증 실패 결과를 반환하고 저장하지 않는다")
+        public void whenCodeInvalid() {
+            // given
+            AuthMailCode authMailCode = AuthMailCodeFixture.builder()
+                    .code("123456")
+                    .build();
+
+            AuthMailCodeValidateCommand command = AuthMailCodeValidateCommandFixture.builder()
+                    .email(authMailCode.getEmail())
+                    .code("000000")
+                    .build();
+
+            doReturn(Optional.of(authMailCode)).when(authMailCodeQueryPort).findById(any());
+
+            // when
+            AuthMailCodeValidateResult result = authCommandService.validateAuthMailCode(command);
+
+            // then
+            verify(authMailCodeQueryPort).findById(command.getEmail());
+            verify(authMailCodeCommandPort, never()).save(any());
+            assertThat(result.isSuccess()).isFalse();
+        }
+
+        @Test
+        @DisplayName("인증 코드가 존재하지 않거나 만료되었으면 VerificationCodeNotFoundException을 던진다")
+        public void whenAuthMailCodeNotFound() {
+            // given
+            AuthMailCodeValidateCommand command = AuthMailCodeValidateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(authMailCodeQueryPort).findById(any());
+
+            // when & then
+            assertThrows(
+                    VerificationCodeNotFoundException.class,
+                    () -> authCommandService.validateAuthMailCode(command)
+            );
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/auth/application/support/fixture/AuthMailCodeValidateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/auth/application/support/fixture/AuthMailCodeValidateCommandFixture.java
@@ -1,0 +1,34 @@
+package com.benchpress200.photique.auth.application.support.fixture;
+
+import com.benchpress200.photique.auth.application.command.model.AuthMailCodeValidateCommand;
+
+public class AuthMailCodeValidateCommandFixture {
+    private AuthMailCodeValidateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String email = "test@example.com";
+        private String code = "123456";
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public AuthMailCodeValidateCommand build() {
+            return AuthMailCodeValidateCommand.builder()
+                    .email(email)
+                    .code(code)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#334 요구에 따라서 인증 메일 코드 검증 유스케이스(`AuthCommandService.validateAuthMailCode()`)에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 단위 테스트 코드를 작성했습니다.
- 코드 일치
- 코드 불일치
- 인증 코드 미존재 또는 만료

Closes #334