### PR TITLE
test(auth): 비밀번호 초기화 인증 메일 전송 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/auth/application/command/AuthCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/auth/application/command/AuthCommandServiceTest.java
@@ -3,11 +3,13 @@ package com.benchpress200.photique.auth.application.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.benchpress200.photique.auth.application.command.model.AuthMailCodeValidateCommand;
+import com.benchpress200.photique.auth.application.command.model.AuthMailCommand;
 import com.benchpress200.photique.auth.application.command.port.out.mail.MailSenderPort;
 import com.benchpress200.photique.auth.application.command.port.out.persistence.AuthMailCodeCommandPort;
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
@@ -15,7 +17,9 @@ import com.benchpress200.photique.auth.application.command.result.AuthMailCodeVa
 import com.benchpress200.photique.auth.application.command.service.AuthCommandService;
 import com.benchpress200.photique.auth.application.query.port.out.persistence.AuthMailCodeQueryPort;
 import com.benchpress200.photique.auth.application.support.fixture.AuthMailCodeValidateCommandFixture;
+import com.benchpress200.photique.auth.application.support.fixture.AuthMailCommandFixture;
 import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
+import com.benchpress200.photique.auth.domain.exception.EmailNotFoundException;
 import com.benchpress200.photique.auth.domain.exception.VerificationCodeNotFoundException;
 import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
 import com.benchpress200.photique.support.base.BaseServiceTest;
@@ -111,6 +115,44 @@ public class AuthCommandServiceTest extends BaseServiceTest {
                     VerificationCodeNotFoundException.class,
                     () -> authCommandService.validateAuthMailCode(command)
             );
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 초기화 인증 메일 전송")
+    class SendPasswordAuthMailTest {
+        @Test
+        @DisplayName("유저가 존재하면 인증 메일을 전송하고 인증 코드를 저장한다")
+        public void whenUserExists() {
+            // given
+            AuthMailCommand command = AuthMailCommandFixture.builder().build();
+
+            doReturn(true).when(userQueryPort).existsByEmail(any());
+            doNothing().when(mailSenderPort).sendMail(any());
+
+            // when
+            authCommandService.sendPasswordAuthMail(command);
+
+            // then
+            verify(userQueryPort).existsByEmail(command.getEmail());
+            verify(mailSenderPort).sendMail(any());
+            verify(authMailCodeCommandPort).save(any());
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 EmailNotFoundException을 던진다")
+        public void whenUserNotFound() {
+            // given
+            AuthMailCommand command = AuthMailCommandFixture.builder().build();
+
+            doReturn(false).when(userQueryPort).existsByEmail(any());
+
+            // when & then
+            assertThrows(
+                    EmailNotFoundException.class,
+                    () -> authCommandService.sendPasswordAuthMail(command)
+            );
+            verify(mailSenderPort, never()).sendMail(any());
         }
     }
 }

--- a/src/test/java/com/benchpress200/photique/auth/application/support/fixture/AuthMailCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/auth/application/support/fixture/AuthMailCommandFixture.java
@@ -1,0 +1,27 @@
+package com.benchpress200.photique.auth.application.support.fixture;
+
+import com.benchpress200.photique.auth.application.command.model.AuthMailCommand;
+
+public class AuthMailCommandFixture {
+    private AuthMailCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String email = "test@example.com";
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public AuthMailCommand build() {
+            return AuthMailCommand.builder()
+                    .email(email)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#333 요구에 따라서 비밀번호 초기화 인증 메일 전송 유스케이스(`AuthCommandService.sendPasswordAuthMail()`)에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 단위 테스트 코드를 작성했습니다.
- 유저 존재
- 유저 미존재

Closes #333