### PR TITLE
test(exhibition): 내 전시회 검색 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionQueryServiceTest.java
@@ -1,0 +1,110 @@
+package com.benchpress200.photique.exhibition.application.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.event.ExhibitionViewCountPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionBookmarkQueryPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionLikeQueryPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionTagQueryPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionWorkQueryPort;
+import com.benchpress200.photique.exhibition.application.query.service.ExhibitionQueryService;
+import com.benchpress200.photique.singlework.application.query.model.MyExhibitionSearchQuery;
+import com.benchpress200.photique.singlework.application.query.result.MyExhibitionSearchResult;
+import com.benchpress200.photique.singlework.application.query.support.fixture.MyExhibitionSearchQueryFixture;
+import com.benchpress200.photique.support.base.BaseServiceTest;
+import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+
+@DisplayName("전시회 쿼리 서비스 테스트")
+public class ExhibitionQueryServiceTest extends BaseServiceTest {
+    @InjectMocks
+    private ExhibitionQueryService exhibitionQueryService;
+
+    @Mock
+    private AuthenticationUserProviderPort authenticationUserProviderPort;
+
+    @Mock
+    private FollowQueryPort followQueryPort;
+
+    @Mock
+    private ExhibitionViewCountPort exhibitionViewCountPort;
+
+    @Mock
+    private ExhibitionCommandPort exhibitionCommandPort;
+
+    @Mock
+    private ExhibitionQueryPort exhibitionQueryPort;
+
+    @Mock
+    private ExhibitionTagQueryPort exhibitionTagQueryPort;
+
+    @Mock
+    private ExhibitionWorkQueryPort exhibitionWorkQueryPort;
+
+    @Mock
+    private ExhibitionLikeQueryPort exhibitionLikeQueryPort;
+
+    @Mock
+    private ExhibitionBookmarkQueryPort exhibitionBookmarkQueryPort;
+
+    @Nested
+    @DisplayName("내 전시회 검색")
+    class SearchMyExhibitionTest {
+        @Test
+        @DisplayName("인증된 유저이면 좋아요/북마크 정보가 포함된 검색 결과를 반환한다")
+        public void whenAuthenticated() {
+            // given
+            MyExhibitionSearchQuery query = MyExhibitionSearchQueryFixture.builder().build();
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Page.empty()).when(exhibitionQueryPort).searchMyExhibitionByDeletedAtIsNull(any(), any(), any());
+            doReturn(true).when(authenticationUserProviderPort).isAuthenticated();
+            doReturn(Set.of()).when(exhibitionLikeQueryPort).findExhibitionIds(any(), any());
+            doReturn(Set.of()).when(exhibitionBookmarkQueryPort).findExhibitionIds(any(), any());
+
+            // when
+            MyExhibitionSearchResult result = exhibitionQueryService.searchMyExhibition(query);
+
+            // then
+            verify(authenticationUserProviderPort, Mockito.times(3)).getCurrentUserId();
+            verify(exhibitionQueryPort).searchMyExhibitionByDeletedAtIsNull(any(), any(), any());
+            verify(exhibitionLikeQueryPort).findExhibitionIds(any(), any());
+            verify(exhibitionBookmarkQueryPort).findExhibitionIds(any(), any());
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 유저이면 좋아요/북마크 조회 없이 검색 결과를 반환한다")
+        public void whenNotAuthenticated() {
+            // given
+            MyExhibitionSearchQuery query = MyExhibitionSearchQueryFixture.builder().build();
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Page.empty()).when(exhibitionQueryPort).searchMyExhibitionByDeletedAtIsNull(any(), any(), any());
+            doReturn(false).when(authenticationUserProviderPort).isAuthenticated();
+
+            // when
+            MyExhibitionSearchResult result = exhibitionQueryService.searchMyExhibition(query);
+
+            // then
+            verify(exhibitionQueryPort).searchMyExhibitionByDeletedAtIsNull(any(), any(), any());
+            verify(exhibitionLikeQueryPort, never()).findExhibitionIds(any(), any());
+            verify(exhibitionBookmarkQueryPort, never()).findExhibitionIds(any(), any());
+            assertThat(result).isNotNull();
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/MyExhibitionSearchQueryFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/query/support/fixture/MyExhibitionSearchQueryFixture.java
@@ -1,0 +1,36 @@
+package com.benchpress200.photique.singlework.application.query.support.fixture;
+
+import com.benchpress200.photique.singlework.application.query.model.MyExhibitionSearchQuery;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public class MyExhibitionSearchQueryFixture {
+    private MyExhibitionSearchQueryFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String keyword = "기본 키워드";
+        private Pageable pageable = PageRequest.of(0, 30);
+
+        public Builder keyword(String keyword) {
+            this.keyword = keyword;
+            return this;
+        }
+
+        public Builder pageable(Pageable pageable) {
+            this.pageable = pageable;
+            return this;
+        }
+
+        public MyExhibitionSearchQuery build() {
+            return MyExhibitionSearchQuery.builder()
+                    .keyword(keyword)
+                    .pageable(pageable)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#331 요구에 따라서 ExhibitionQueryService.searchMyExhibition()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 인증된 유저이면 좋아요/북마크 정보가 포함된 검색 결과를 반환한다
- 인증되지 않은 유저이면 좋아요/북마크 조회 없이 검색 결과를 반환한다

Closes #331