### PR TITLE
test(exhibition): 전시회 수정 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
@@ -402,7 +402,8 @@ public class ExhibitionCommandServiceTest extends BaseServiceTest {
                     .updateWorks(true)
                     .update(false)
                     .build();
-            ExhibitionWork work = ExhibitionWorkFixture.builder().displayOrder(1).build();
+            ExhibitionWork work = ExhibitionWorkFixture.builder().displayOrder(1)
+                    .build(); // 업데이트 커맨드를 통해 order가 0으로 설정됨
             ExhibitionWork anotherWork = ExhibitionWorkFixture.builder().displayOrder(0).build();
 
             doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());

--- a/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
 import com.benchpress200.photique.exhibition.application.command.model.ExhibitionCreateCommand;
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionUpdateCommand;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionEventPublishPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionTagCommandPort;
@@ -19,8 +20,15 @@ import com.benchpress200.photique.exhibition.application.query.port.out.persiste
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionTagQueryPort;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionWorkQueryPort;
 import com.benchpress200.photique.exhibition.application.support.fixture.ExhibitionCreateCommandFixture;
+import com.benchpress200.photique.exhibition.application.support.fixture.ExhibitionUpdateCommandFixture;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionWork;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionNotFoundException;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionNotOwnedException;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionWorkDuplicatedDisplayOrderException;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionWorkNotFoundException;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionWorkFixture;
 import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
 import com.benchpress200.photique.outbox.application.factory.OutboxEventFactory;
 import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
@@ -280,6 +288,160 @@ public class ExhibitionCommandServiceTest extends BaseServiceTest {
             verify(exhibitionWorkCommandPort).save(any());
             verify(exhibitionTagCommandPort).saveAll(any());
             verify(outboxEventPort).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("전시회 수정")
+    class UpdateExhibitionDetailsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder().build();
+            ExhibitionWork work = ExhibitionWorkFixture.builder().displayOrder(0).build();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doNothing().when(exhibitionTagCommandPort).deleteByExhibition(any());
+            doReturn(List.of()).when(tagQueryPort).findByNameIn(any());
+            doReturn(List.of()).when(tagCommandPort).saveAll(any());
+            doReturn(List.of()).when(exhibitionTagCommandPort).saveAll(any());
+            doReturn(Optional.of(work)).when(exhibitionWorkQueryPort).findById(any());
+            doReturn(List.of(work)).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(outboxEvent).when(outboxEventFactory).exhibitionUpdated(any(), any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+            // when
+            exhibitionCommandService.updateExhibitionDetailsUpdate(command);
+
+            // then
+            verify(exhibitionTagCommandPort).deleteByExhibition(exhibition);
+            verify(exhibitionTagCommandPort).saveAll(any());
+            verify(exhibitionWorkQueryPort).findById(any());
+            verify(exhibitionWorkQueryPort).findByExhibition(exhibition);
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("전시회가 존재하지 않으면 ExhibitionNotFoundException을 던진다")
+        public void whenExhibitionNotFound() {
+            // given
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    ExhibitionNotFoundException.class,
+                    () -> exhibitionCommandService.updateExhibitionDetailsUpdate(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("전시회의 소유자가 아니면 ExhibitionNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    ExhibitionNotOwnedException.class,
+                    () -> exhibitionCommandService.updateExhibitionDetailsUpdate(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("전시회 개별 작품이 존재하지 않으면 ExhibitionWorkNotFoundException을 던진다")
+        public void whenExhibitionWorkNotFound() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder()
+                    .updateTitle(false)
+                    .updateDescription(false)
+                    .updateCardColor(false)
+                    .updateTags(false)
+                    .updateWorks(true)
+                    .update(false)
+                    .build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.empty()).when(exhibitionWorkQueryPort).findById(any());
+
+            // when & then
+            assertThrows(
+                    ExhibitionWorkNotFoundException.class,
+                    () -> exhibitionCommandService.updateExhibitionDetailsUpdate(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("전시회 개별 작품의 displayOrder가 중복이면 ExhibitionWorkDuplicatedDisplayOrderException을 던진다")
+        public void whenDuplicatedDisplayOrder() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder()
+                    .updateTitle(false)
+                    .updateDescription(false)
+                    .updateCardColor(false)
+                    .updateTags(false)
+                    .updateWorks(true)
+                    .update(false)
+                    .build();
+            ExhibitionWork work = ExhibitionWorkFixture.builder().displayOrder(1).build();
+            ExhibitionWork anotherWork = ExhibitionWorkFixture.builder().displayOrder(0).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(work)).when(exhibitionWorkQueryPort).findById(any());
+            doReturn(List.of(work, anotherWork)).when(exhibitionWorkQueryPort).findByExhibition(any());
+
+            // when & then
+            assertThrows(
+                    ExhibitionWorkDuplicatedDisplayOrderException.class,
+                    () -> exhibitionCommandService.updateExhibitionDetailsUpdate(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("업데이트 사항이 없으면 아웃박스 이벤트 저장을 진행하지 않는다")
+        public void whenNoUpdates() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            ExhibitionUpdateCommand command = ExhibitionUpdateCommandFixture.builder()
+                    .updateTitle(false)
+                    .updateDescription(false)
+                    .updateCardColor(false)
+                    .updateTags(false)
+                    .updateWorks(false)
+                    .update(false)
+                    .build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+
+            // when
+            exhibitionCommandService.updateExhibitionDetailsUpdate(command);
+
+            // then
+            verify(exhibitionTagCommandPort, never()).deleteByExhibition(any());
+            verify(outboxEventPort, never()).save(any());
         }
     }
 }

--- a/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionUpdateCommandFixture.java
@@ -1,0 +1,108 @@
+package com.benchpress200.photique.exhibition.application.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionUpdateCommand;
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionWorkUpdateCommand;
+import java.util.List;
+
+public class ExhibitionUpdateCommandFixture {
+    private ExhibitionUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long exhibitionId = 1L;
+        private boolean updateTitle = true;
+        private String title = "수정된 제목";
+        private boolean updateDescription = true;
+        private String description = "수정된 설명";
+        private boolean updateCardColor = true;
+        private String cardColor = "#000000";
+        private boolean updateTags = true;
+        private List<String> tags = List.of("수정태그1");
+        private boolean updateWorks = true;
+        private List<ExhibitionWorkUpdateCommand> works = List.of(
+                ExhibitionWorkUpdateCommandFixture.builder().build()
+        );
+        private boolean update = true;
+
+        public Builder exhibitionId(Long exhibitionId) {
+            this.exhibitionId = exhibitionId;
+            return this;
+        }
+
+        public Builder updateTitle(boolean updateTitle) {
+            this.updateTitle = updateTitle;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder updateDescription(boolean updateDescription) {
+            this.updateDescription = updateDescription;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder updateCardColor(boolean updateCardColor) {
+            this.updateCardColor = updateCardColor;
+            return this;
+        }
+
+        public Builder cardColor(String cardColor) {
+            this.cardColor = cardColor;
+            return this;
+        }
+
+        public Builder updateTags(boolean updateTags) {
+            this.updateTags = updateTags;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder updateWorks(boolean updateWorks) {
+            this.updateWorks = updateWorks;
+            return this;
+        }
+
+        public Builder works(List<ExhibitionWorkUpdateCommand> works) {
+            this.works = works;
+            return this;
+        }
+
+        public Builder update(boolean update) {
+            this.update = update;
+            return this;
+        }
+
+        public ExhibitionUpdateCommand build() {
+            return ExhibitionUpdateCommand.builder()
+                    .exhibitionId(exhibitionId)
+                    .updateTitle(updateTitle)
+                    .title(title)
+                    .updateDescription(updateDescription)
+                    .description(description)
+                    .updateCardColor(updateCardColor)
+                    .cardColor(cardColor)
+                    .updateTags(updateTags)
+                    .tags(tags)
+                    .updateWorks(updateWorks)
+                    .works(works)
+                    .update(update)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionWorkUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionWorkUpdateCommandFixture.java
@@ -1,0 +1,48 @@
+package com.benchpress200.photique.exhibition.application.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionWorkUpdateCommand;
+
+public class ExhibitionWorkUpdateCommandFixture {
+    private ExhibitionWorkUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id = 1L;
+        private Integer displayOrder = 0;
+        private String title = "수정된 작품 제목";
+        private String description = "수정된 작품 설명";
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder displayOrder(Integer displayOrder) {
+            this.displayOrder = displayOrder;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public ExhibitionWorkUpdateCommand build() {
+            return ExhibitionWorkUpdateCommand.builder()
+                    .id(id)
+                    .displayOrder(displayOrder)
+                    .title(title)
+                    .description(description)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionWorkFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionWorkFixture.java
@@ -1,0 +1,56 @@
+package com.benchpress200.photique.exhibition.domain.support;
+
+import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionWork;
+
+public class ExhibitionWorkFixture {
+    private ExhibitionWorkFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+        private Integer displayOrder = 0;
+        private String title = "기본 작품 제목";
+        private String description = "기본 작품 설명";
+        private String image = "https://test-bucket/exhibition/work.jpg";
+
+        public Builder exhibition(Exhibition exhibition) {
+            this.exhibition = exhibition;
+            return this;
+        }
+
+        public Builder displayOrder(Integer displayOrder) {
+            this.displayOrder = displayOrder;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder image(String image) {
+            this.image = image;
+            return this;
+        }
+
+        public ExhibitionWork build() {
+            return ExhibitionWork.builder()
+                    .exhibition(exhibition)
+                    .displayOrder(displayOrder)
+                    .title(title)
+                    .description(description)
+                    .image(image)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#319 요구에 따라서 ExhibitionCommandService.updateExhibitionDetailsUpdate()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 전체 업데이트가 정상적으로 처리되는 경우
- 전시회가 존재하지 않아 ExhibitionNotFoundException이 발생하는 경우
- 전시회의 소유자가 아니어서 ExhibitionNotOwnedException이 발생하는 경우
- 전시회 개별 작품이 존재하지 않아 ExhibitionWorkNotFoundException이 발생하는 경우
- 전시회 개별 작품의 displayOrder가 중복이어서 ExhibitionWorkDuplicatedDisplayOrderException이 발생하는 경우
- 업데이트 사항이 없어 아웃박스 이벤트 저장을 진행하지 않는 경우

Closes #319