### PR TITLE
test(exhibition): 전시회 삭제 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommandServiceTest.java
@@ -445,4 +445,59 @@ public class ExhibitionCommandServiceTest extends BaseServiceTest {
             verify(outboxEventPort, never()).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("전시회 삭제")
+    class DeleteExhibitionTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(outboxEvent).when(outboxEventFactory).exhibitionDeleted(any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+            // when
+            exhibitionCommandService.deleteExhibition(exhibition.getId());
+
+            // then
+            verify(outboxEventFactory).exhibitionDeleted(exhibition);
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("전시회가 존재하지 않으면 아무 처리도 하지 않는다")
+        public void whenExhibitionNotFound() {
+            // given
+            doReturn(Optional.empty()).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            exhibitionCommandService.deleteExhibition(1L);
+
+            // then
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("전시회 소유자가 아니면 ExhibitionNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).writerId(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProviderPort).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    ExhibitionNotOwnedException.class,
+                    () -> exhibitionCommandService.deleteExhibition(exhibition.getId())
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+    }
 }


### PR DESCRIPTION
# 목적
#320 요구에 따라서 ExhibitionCommandService.deleteExhibition()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 전시회가 존재하고 소유자가 일치하면 처리에 성공한다
- 전시회가 존재하지 않으면 아무 처리도 하지 않는다
- 전시회 소유자가 아니면 ExhibitionNotOwnedException을 던진다

Closes #320