### PR TITLE
test(exhibition): 전시회 감상평 수정 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommentCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommentCommandServiceTest.java
@@ -9,13 +9,19 @@ import static org.mockito.Mockito.verify;
 
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
 import com.benchpress200.photique.exhibition.application.command.model.ExhibitionCommentCreateCommand;
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionCommentUpdateCommand;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommentCommandPort;
 import com.benchpress200.photique.exhibition.application.command.service.ExhibitionCommentCommandService;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionCommentQueryPort;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
 import com.benchpress200.photique.exhibition.application.support.fixture.ExhibitionCommentCreateCommandFixture;
+import com.benchpress200.photique.exhibition.application.support.fixture.ExhibitionCommentUpdateCommandFixture;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionComment;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionCommentNotFoundException;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionCommentNotOwnedException;
 import com.benchpress200.photique.exhibition.domain.exception.ExhibitionNotFoundException;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionCommentFixture;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
 import com.benchpress200.photique.outbox.application.factory.OutboxEventFactory;
 import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
@@ -144,6 +150,62 @@ public class ExhibitionCommentCommandServiceTest extends BaseServiceTest {
                     () -> exhibitionCommentCommandService.createExhibitionComment(command)
             );
             verify(exhibitionCommentCommandPort, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("전시회 감상평 수정")
+    class UpdateExhibitionCommentTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            ExhibitionComment exhibitionComment = ExhibitionCommentFixture.builder().writer(writer).build();
+            ExhibitionCommentUpdateCommand command = ExhibitionCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(exhibitionComment)).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProvider).getCurrentUserId();
+
+            // when
+            exhibitionCommentCommandService.updateExhibitionComment(command);
+
+            // then
+            verify(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(command.getCommentId());
+            verify(authenticationUserProvider).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("감상평이 존재하지 않으면 ExhibitionCommentNotFoundException을 던진다")
+        public void whenCommentNotFound() {
+            // given
+            ExhibitionCommentUpdateCommand command = ExhibitionCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    ExhibitionCommentNotFoundException.class,
+                    () -> exhibitionCommentCommandService.updateExhibitionComment(command)
+            );
+        }
+
+        @Test
+        @DisplayName("감상평 소유자가 아니면 ExhibitionCommentNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            ExhibitionComment exhibitionComment = ExhibitionCommentFixture.builder().writer(writer).build();
+            ExhibitionCommentUpdateCommand command = ExhibitionCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(exhibitionComment)).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProvider).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    ExhibitionCommentNotOwnedException.class,
+                    () -> exhibitionCommentCommandService.updateExhibitionComment(command)
+            );
         }
     }
 }

--- a/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionCommentUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/support/fixture/ExhibitionCommentUpdateCommandFixture.java
@@ -1,0 +1,34 @@
+package com.benchpress200.photique.exhibition.application.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.command.model.ExhibitionCommentUpdateCommand;
+
+public class ExhibitionCommentUpdateCommandFixture {
+    private ExhibitionCommentUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long commentId = 1L;
+        private String content = "수정된 감상평";
+
+        public Builder commentId(Long commentId) {
+            this.commentId = commentId;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public ExhibitionCommentUpdateCommand build() {
+            return ExhibitionCommentUpdateCommand.builder()
+                    .commentId(commentId)
+                    .content(content)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionCommentFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionCommentFixture.java
@@ -1,0 +1,44 @@
+package com.benchpress200.photique.exhibition.domain.support;
+
+import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionComment;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+
+public class ExhibitionCommentFixture {
+    private ExhibitionCommentFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private User writer = UserFixture.builder().id(1L).build();
+        private Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+        private String content = "기본 감상평";
+
+        public Builder writer(User writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder exhibition(Exhibition exhibition) {
+            this.exhibition = exhibition;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public ExhibitionComment build() {
+            return ExhibitionComment.builder()
+                    .writer(writer)
+                    .exhibition(exhibition)
+                    .content(content)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#322 요구에 따라서 ExhibitionCommentCommandService.updateExhibitionComment()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 감상평이 존재하고 소유자가 일치하면 처리에 성공한다
- 감상평이 존재하지 않으면 ExhibitionCommentNotFoundException을 던진다
- 감상평 소유자가 아니면 ExhibitionCommentNotOwnedException을 던진다

Closes #322