### PR TITLE
test(exhibition): 전시회 감상평 삭제 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommentCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/command/ExhibitionCommentCommandServiceTest.java
@@ -208,4 +208,56 @@ public class ExhibitionCommentCommandServiceTest extends BaseServiceTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("전시회 감상평 삭제")
+    class DeleteExhibitionCommentTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            ExhibitionComment exhibitionComment = ExhibitionCommentFixture.builder().writer(writer).build();
+
+            doReturn(Optional.of(exhibitionComment)).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProvider).getCurrentUserId();
+
+            // when
+            exhibitionCommentCommandService.deleteExhibitionComment(1L);
+
+            // then
+            verify(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(1L);
+            verify(authenticationUserProvider).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("감상평이 존재하지 않으면 아무 처리도 하지 않는다")
+        public void whenCommentNotFound() {
+            // given
+            doReturn(Optional.empty()).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            exhibitionCommentCommandService.deleteExhibitionComment(1L);
+
+            // then
+            verify(authenticationUserProvider, never()).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("감상평 소유자가 아니면 ExhibitionCommentNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            ExhibitionComment exhibitionComment = ExhibitionCommentFixture.builder().writer(writer).build();
+
+            doReturn(Optional.of(exhibitionComment)).when(exhibitionCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProvider).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    ExhibitionCommentNotOwnedException.class,
+                    () -> exhibitionCommentCommandService.deleteExhibitionComment(1L)
+            );
+        }
+    }
 }


### PR DESCRIPTION
# 목적
#323 요구에 따라서 ExhibitionCommentCommandService.deleteExhibitionComment()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 감상평이 존재하고 소유자가 일치하면 처리에 성공한다
- 감상평이 존재하지 않으면 아무 처리도 하지 않는다
- 감상평 소유자가 아니면 ExhibitionCommentNotOwnedException을 던진다

Closes #323