### PR TITLE
test(exhibition): 전시회 감상평 페이지 조회 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionCommentQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionCommentQueryServiceTest.java
@@ -1,0 +1,65 @@
+package com.benchpress200.photique.exhibition.application.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.benchpress200.photique.exhibition.application.query.model.ExhibitionCommentsQuery;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionCommentQueryPort;
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionCommentsResult;
+import com.benchpress200.photique.exhibition.application.query.service.ExhibitionCommentQueryService;
+import com.benchpress200.photique.exhibition.application.query.support.fixture.ExhibitionCommentsQueryFixture;
+import com.benchpress200.photique.support.base.BaseServiceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+
+@DisplayName("전시회 감상평 쿼리 서비스 테스트")
+public class ExhibitionCommentQueryServiceTest extends BaseServiceTest {
+    @InjectMocks
+    private ExhibitionCommentQueryService exhibitionCommentQueryService;
+
+    @Mock
+    private ExhibitionCommentQueryPort exhibitionCommentQueryPort;
+
+    @Nested
+    @DisplayName("전시회 감상평 페이지 조회")
+    class GetExhibitionCommentsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            ExhibitionCommentsQuery query = ExhibitionCommentsQueryFixture.builder().build();
+
+            doReturn(Page.empty()).when(exhibitionCommentQueryPort).findByExhibitionId(any(), any());
+
+            // when
+            ExhibitionCommentsResult result = exhibitionCommentQueryService.getExhibitionComments(query);
+
+            // then
+            verify(exhibitionCommentQueryPort).findByExhibitionId(query.getExhibitionId(), query.getPageable());
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("감상평 조회에 실패하면 예외를 던진다")
+        public void whenCommentQueryFails() {
+            // given
+            ExhibitionCommentsQuery query = ExhibitionCommentsQueryFixture.builder().build();
+
+            doThrow(new RuntimeException()).when(exhibitionCommentQueryPort).findByExhibitionId(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionCommentQueryService.getExhibitionComments(query)
+            );
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionCommentsQueryFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/support/fixture/ExhibitionCommentsQueryFixture.java
@@ -1,0 +1,36 @@
+package com.benchpress200.photique.exhibition.application.query.support.fixture;
+
+import com.benchpress200.photique.exhibition.application.query.model.ExhibitionCommentsQuery;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public class ExhibitionCommentsQueryFixture {
+    private ExhibitionCommentsQueryFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long exhibitionId = 1L;
+        private Pageable pageable = PageRequest.of(0, 5);
+
+        public Builder exhibitionId(Long exhibitionId) {
+            this.exhibitionId = exhibitionId;
+            return this;
+        }
+
+        public Builder pageable(Pageable pageable) {
+            this.pageable = pageable;
+            return this;
+        }
+
+        public ExhibitionCommentsQuery build() {
+            return ExhibitionCommentsQuery.builder()
+                    .exhibitionId(exhibitionId)
+                    .pageable(pageable)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#327 요구에 따라서 ExhibitionCommentQueryService.getExhibitionComments()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 감상평 조회에 실패하면 예외를 던진다

Closes #327