### PR TITLE
test(exhibition): 전시회 상세 조회 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/application/query/ExhibitionQueryServiceTest.java
@@ -1,8 +1,10 @@
 package com.benchpress200.photique.exhibition.application.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -14,12 +16,18 @@ import com.benchpress200.photique.exhibition.application.query.port.out.persiste
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionTagQueryPort;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionWorkQueryPort;
+import com.benchpress200.photique.exhibition.application.query.result.ExhibitionDetailsResult;
 import com.benchpress200.photique.exhibition.application.query.service.ExhibitionQueryService;
+import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.exception.ExhibitionNotFoundException;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
 import com.benchpress200.photique.singlework.application.query.model.MyExhibitionSearchQuery;
 import com.benchpress200.photique.singlework.application.query.result.MyExhibitionSearchResult;
 import com.benchpress200.photique.singlework.application.query.support.fixture.MyExhibitionSearchQueryFixture;
 import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 
 @DisplayName("전시회 쿼리 서비스 테스트")
@@ -60,6 +69,197 @@ public class ExhibitionQueryServiceTest extends BaseServiceTest {
 
     @Mock
     private ExhibitionBookmarkQueryPort exhibitionBookmarkQueryPort;
+
+    @Nested
+    @DisplayName("전시회 상세 조회")
+    class GetExhibitionDetailsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            doReturn(false).when(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doReturn(false).when(exhibitionBookmarkQueryPort).existsByUserIdAndExhibitionId(any(), any());
+
+            // when
+            ExhibitionDetailsResult result = exhibitionQueryService.getExhibitionDetails(exhibition.getId());
+
+            // then
+            verify(exhibitionQueryPort).findByIdAndDeletedAtIsNull(exhibition.getId());
+            verify(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            verify(exhibitionWorkQueryPort).findByExhibition(any());
+            verify(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            verify(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            verify(exhibitionBookmarkQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            verify(exhibitionViewCountPort).incrementViewCount(exhibition.getId());
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("전시회가 존재하지 않으면 ExhibitionNotFoundException을 던진다")
+        public void whenExhibitionNotFound() {
+            // given
+            doReturn(Optional.empty()).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    ExhibitionNotFoundException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(1L)
+            );
+            verify(exhibitionTagQueryPort, never()).findByExhibitionWithTag(any());
+        }
+
+        @Test
+        @DisplayName("태그 조회에 실패하면 예외를 던진다")
+        public void whenTagQueryFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doThrow(new RuntimeException()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+            verify(exhibitionWorkQueryPort, never()).findByExhibition(any());
+        }
+
+        @Test
+        @DisplayName("작품 조회에 실패하면 예외를 던진다")
+        public void whenWorkQueryFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doThrow(new RuntimeException()).when(exhibitionWorkQueryPort).findByExhibition(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+            verify(followQueryPort, never()).existsByFollowerIdAndFolloweeId(any(), any());
+        }
+
+        @Test
+        @DisplayName("팔로우 조회에 실패하면 예외를 던진다")
+        public void whenFollowQueryFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doThrow(new RuntimeException()).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+            verify(exhibitionLikeQueryPort, never()).existsByUserIdAndExhibitionId(any(), any());
+        }
+
+        @Test
+        @DisplayName("좋아요 조회에 실패하면 예외를 던진다")
+        public void whenLikeQueryFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            doThrow(new RuntimeException()).when(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+            verify(exhibitionBookmarkQueryPort, never()).existsByUserIdAndExhibitionId(any(), any());
+        }
+
+        @Test
+        @DisplayName("북마크 조회에 실패하면 예외를 던진다")
+        public void whenBookmarkQueryFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            doReturn(false).when(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doThrow(new RuntimeException()).when(exhibitionBookmarkQueryPort).existsByUserIdAndExhibitionId(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+            verify(exhibitionViewCountPort, never()).incrementViewCount(any());
+        }
+
+        @Test
+        @DisplayName("조회수 증가에 실패하면 fallback으로 exhibitionCommandPort를 호출한다")
+        public void whenViewCountFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            doReturn(false).when(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doReturn(false).when(exhibitionBookmarkQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doThrow(new DataAccessException("조회수 증가 실패") {
+            }).when(exhibitionViewCountPort).incrementViewCount(any());
+
+            // when
+            exhibitionQueryService.getExhibitionDetails(exhibition.getId());
+
+            // then
+            verify(exhibitionCommandPort).incrementViewCount(exhibition.getId());
+        }
+
+        @Test
+        @DisplayName("조회수 증가 fallback에도 실패하면 예외를 던진다")
+        public void whenViewCountFallbackFails() {
+            // given
+            Exhibition exhibition = ExhibitionFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(exhibition)).when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(List.of()).when(exhibitionTagQueryPort).findByExhibitionWithTag(any());
+            doReturn(List.of()).when(exhibitionWorkQueryPort).findByExhibition(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            doReturn(false).when(exhibitionLikeQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doReturn(false).when(exhibitionBookmarkQueryPort).existsByUserIdAndExhibitionId(any(), any());
+            doThrow(new DataAccessException("조회수 증가 실패") {
+            }).when(exhibitionViewCountPort).incrementViewCount(any());
+            doThrow(new RuntimeException()).when(exhibitionCommandPort).incrementViewCount(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> exhibitionQueryService.getExhibitionDetails(exhibition.getId())
+            );
+        }
+    }
 
     @Nested
     @DisplayName("내 전시회 검색")


### PR DESCRIPTION
# 목적
#329 요구에 따라서 ExhibitionQueryService.getExhibitionDetails()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 전시회가 존재하지 않으면 ExhibitionNotFoundException을 던진다
- 태그 조회에 실패하면 예외를 던진다
- 작품 조회에 실패하면 예외를 던진다
- 팔로우 조회에 실패하면 예외를 던진다
- 좋아요 조회에 실패하면 예외를 던진다
- 북마크 조회에 실패하면 예외를 던진다
- 조회수 증가에 실패하면 fallback으로 exhibitionCommandPort를 호출한다
- 조회수 증가 fallback에도 실패하면 예외를 던진다

Closes #329