### PR TITLE
test(notification): 알림 읽음 표시 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/notification/application/command/NotificationCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/notification/application/command/NotificationCommandServiceTest.java
@@ -1,0 +1,82 @@
+package com.benchpress200.photique.notification.application.command;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
+import com.benchpress200.photique.notification.application.command.port.out.persistence.NotificationCommandPort;
+import com.benchpress200.photique.notification.application.command.service.NotificationCommandService;
+import com.benchpress200.photique.notification.application.query.port.out.persistence.NotificationQueryPort;
+import com.benchpress200.photique.notification.domain.entity.Notification;
+import com.benchpress200.photique.notification.domain.exception.NotificationNotFoundException;
+import com.benchpress200.photique.notification.domain.support.NotificationFixture;
+import com.benchpress200.photique.support.base.BaseServiceTest;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@DisplayName("알림 커맨드 서비스 테스트")
+public class NotificationCommandServiceTest extends BaseServiceTest {
+    @InjectMocks
+    private NotificationCommandService notificationCommandService;
+
+    @Mock
+    private AuthenticationUserProviderPort authenticationUserProviderPort;
+
+    @Mock
+    private NotificationCommandPort notificationCommandPort;
+
+    @Mock
+    private NotificationQueryPort notificationQueryPort;
+
+    @Nested
+    @DisplayName("알림 읽음 표시")
+    class MarkAsReadTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            Notification notification = NotificationFixture.builder().build();
+
+            doReturn(Optional.of(notification)).when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            notificationCommandService.markAsRead(1L);
+
+            // then
+            verify(notificationQueryPort).findByIdAndDeletedAtIsNull(1L);
+        }
+
+        @Test
+        @DisplayName("알림이 존재하지 않으면 NotificationNotFoundException을 던진다")
+        public void whenNotificationNotFound() {
+            // given
+            doReturn(Optional.empty()).when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    NotificationNotFoundException.class,
+                    () -> notificationCommandService.markAsRead(1L)
+            );
+        }
+
+        @Test
+        @DisplayName("알림 조회에 실패하면 예외를 던진다")
+        public void whenNotificationQueryFails() {
+            // given
+            doThrow(new RuntimeException()).when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> notificationCommandService.markAsRead(1L)
+            );
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/notification/domain/support/NotificationFixture.java
+++ b/src/test/java/com/benchpress200/photique/notification/domain/support/NotificationFixture.java
@@ -1,0 +1,44 @@
+package com.benchpress200.photique.notification.domain.support;
+
+import com.benchpress200.photique.notification.domain.entity.Notification;
+import com.benchpress200.photique.notification.domain.enumeration.NotificationType;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+
+public class NotificationFixture {
+    private NotificationFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private User receiver = UserFixture.builder().id(1L).build();
+        private NotificationType type = NotificationType.FOLLOW;
+        private Long targetId = 1L;
+
+        public Builder receiver(User receiver) {
+            this.receiver = receiver;
+            return this;
+        }
+
+        public Builder type(NotificationType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder targetId(Long targetId) {
+            this.targetId = targetId;
+            return this;
+        }
+
+        public Notification build() {
+            return Notification.builder()
+                    .receiver(receiver)
+                    .type(type)
+                    .targetId(targetId)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#312 요구에 따라서 NotificationCommandService.markAsRead()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 알림이 존재하지 않으면 NotificationNotFoundException을 던진다
- 알림 조회에 실패하면 예외를 던진다

Closes #312