### PR TITLE
test(singlework): 단일작품 댓글 수정 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommentCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommentCommandServiceTest.java
@@ -13,13 +13,19 @@ import com.benchpress200.photique.outbox.application.port.out.persistence.Outbox
 import com.benchpress200.photique.outbox.domain.entity.OutboxEvent;
 import com.benchpress200.photique.outbox.domain.support.OutboxEventFixture;
 import com.benchpress200.photique.singlework.application.command.model.SingleWorkCommentCreateCommand;
+import com.benchpress200.photique.singlework.application.command.model.SingleWorkCommentUpdateCommand;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkCommentCommandPort;
 import com.benchpress200.photique.singlework.application.command.service.SingleWorkCommentCommandService;
 import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkCommentQueryPort;
 import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkQueryPort;
 import com.benchpress200.photique.singlework.application.support.fixture.SingleWorkCommentCreateCommandFixture;
+import com.benchpress200.photique.singlework.application.support.fixture.SingleWorkCommentUpdateCommandFixture;
 import com.benchpress200.photique.singlework.domain.entity.SingleWork;
+import com.benchpress200.photique.singlework.domain.entity.SingleWorkComment;
+import com.benchpress200.photique.singlework.domain.exception.SingleWorkCommentNotFoundException;
+import com.benchpress200.photique.singlework.domain.exception.SingleWorkCommentNotOwnedException;
 import com.benchpress200.photique.singlework.domain.exception.SingleWorkNotFoundException;
+import com.benchpress200.photique.singlework.domain.support.SingleWorkCommentFixture;
 import com.benchpress200.photique.singlework.domain.support.SingleWorkFixture;
 import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
@@ -165,6 +171,62 @@ public class SingleWorkCommentCommandServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> singleWorkCommentCommandService.createSingleWorkComment(command)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("단일작품 댓글 수정")
+    class UpdateSingleWorkCommentTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            SingleWorkComment singleWorkComment = SingleWorkCommentFixture.builder().writer(writer).build();
+            SingleWorkCommentUpdateCommand command = SingleWorkCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(singleWorkComment)).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProvider).getCurrentUserId();
+
+            // when
+            singleWorkCommentCommandService.updateSingleWorkComment(command);
+
+            // then
+            verify(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(command.getCommentId());
+            verify(authenticationUserProvider).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 SingleWorkCommentNotFoundException을 던진다")
+        public void whenCommentNotFound() {
+            // given
+            SingleWorkCommentUpdateCommand command = SingleWorkCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    SingleWorkCommentNotFoundException.class,
+                    () -> singleWorkCommentCommandService.updateSingleWorkComment(command)
+            );
+        }
+
+        @Test
+        @DisplayName("댓글 소유자가 아니면 SingleWorkCommentNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            SingleWorkComment singleWorkComment = SingleWorkCommentFixture.builder().writer(writer).build();
+            SingleWorkCommentUpdateCommand command = SingleWorkCommentUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(singleWorkComment)).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProvider).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    SingleWorkCommentNotOwnedException.class,
+                    () -> singleWorkCommentCommandService.updateSingleWorkComment(command)
             );
         }
     }

--- a/src/test/java/com/benchpress200/photique/singlework/application/support/fixture/SingleWorkCommentUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/support/fixture/SingleWorkCommentUpdateCommandFixture.java
@@ -1,0 +1,34 @@
+package com.benchpress200.photique.singlework.application.support.fixture;
+
+import com.benchpress200.photique.singlework.application.command.model.SingleWorkCommentUpdateCommand;
+
+public class SingleWorkCommentUpdateCommandFixture {
+    private SingleWorkCommentUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long commentId = 1L;
+        private String content = "수정된 댓글 내용";
+
+        public Builder commentId(Long commentId) {
+            this.commentId = commentId;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public SingleWorkCommentUpdateCommand build() {
+            return SingleWorkCommentUpdateCommand.builder()
+                    .commentId(commentId)
+                    .content(content)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/singlework/domain/support/SingleWorkCommentFixture.java
+++ b/src/test/java/com/benchpress200/photique/singlework/domain/support/SingleWorkCommentFixture.java
@@ -1,0 +1,44 @@
+package com.benchpress200.photique.singlework.domain.support;
+
+import com.benchpress200.photique.singlework.domain.entity.SingleWork;
+import com.benchpress200.photique.singlework.domain.entity.SingleWorkComment;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+
+public class SingleWorkCommentFixture {
+    private SingleWorkCommentFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private User writer = UserFixture.builder().id(1L).build();
+        private SingleWork singleWork = SingleWorkFixture.builder().build();
+        private String content = "기본 댓글 내용";
+
+        public Builder writer(User writer) {
+            this.writer = writer;
+            return this;
+        }
+
+        public Builder singleWork(SingleWork singleWork) {
+            this.singleWork = singleWork;
+            return this;
+        }
+
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public SingleWorkComment build() {
+            return SingleWorkComment.builder()
+                    .writer(writer)
+                    .singleWork(singleWork)
+                    .content(content)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#303 요구에 따라서 SingleWorkCommentCommandService.updateSingleWorkComment()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 댓글이 존재하지 않으면 SingleWorkCommentNotFoundException을 던진다
- 댓글 소유자가 아니면 SingleWorkCommentNotOwnedException을 던진다

Closes #303