### PR TITLE
test(singlework): 단일작품 댓글 삭제 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommentCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/singlework/application/command/SingleWorkCommentCommandServiceTest.java
@@ -230,4 +230,56 @@ public class SingleWorkCommentCommandServiceTest extends BaseServiceTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("단일작품 댓글 삭제")
+    class DeleteSingleWorkCommentTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            SingleWorkComment singleWorkComment = SingleWorkCommentFixture.builder().writer(writer).build();
+
+            doReturn(Optional.of(singleWorkComment)).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(writer.getId()).when(authenticationUserProvider).getCurrentUserId();
+
+            // when
+            singleWorkCommentCommandService.deleteSingleWorkComment(1L);
+
+            // then
+            verify(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(1L);
+            verify(authenticationUserProvider).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("댓글이 존재하지 않으면 아무 처리도 하지 않는다")
+        public void whenCommentNotFound() {
+            // given
+            doReturn(Optional.empty()).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            singleWorkCommentCommandService.deleteSingleWorkComment(1L);
+
+            // then
+            verify(authenticationUserProvider, never()).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("댓글 소유자가 아니면 SingleWorkCommentNotOwnedException을 던진다")
+        public void whenNotOwner() {
+            // given
+            User writer = UserFixture.builder().id(1L).build();
+            SingleWorkComment singleWorkComment = SingleWorkCommentFixture.builder().writer(writer).build();
+
+            doReturn(Optional.of(singleWorkComment)).when(singleWorkCommentQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(2L).when(authenticationUserProvider).getCurrentUserId();
+
+            // when & then
+            assertThrows(
+                    SingleWorkCommentNotOwnedException.class,
+                    () -> singleWorkCommentCommandService.deleteSingleWorkComment(1L)
+            );
+        }
+    }
 }


### PR DESCRIPTION
# 목적
#304 요구에 따라서 SingleWorkCommentCommandService.deleteSingleWorkComment()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 댓글이 존재하지 않으면 아무 처리도 하지 않는다
- 댓글 소유자가 아니면 SingleWorkCommentNotOwnedException을 던진다

Closes #304