### PR TITLE
test(user): 유저 정보 수정 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
@@ -16,15 +16,22 @@ import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
 import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
 import com.benchpress200.photique.outbox.application.factory.OutboxEventFactory;
 import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
+import com.benchpress200.photique.outbox.domain.entity.OutboxEvent;
+import com.benchpress200.photique.outbox.domain.support.OutboxEventFixture;
 import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.user.application.command.model.ResisterCommand;
+import com.benchpress200.photique.user.application.command.model.UserDetailsUpdateCommand;
 import com.benchpress200.photique.user.application.command.port.out.event.UserEventPublishPort;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.application.command.port.out.security.PasswordEncoderPort;
 import com.benchpress200.photique.user.application.command.service.UserCommandService;
 import com.benchpress200.photique.user.application.command.support.fixture.ResisterCommandFixture;
+import com.benchpress200.photique.user.application.command.support.fixture.UserDetailsUpdateCommandFixture;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
+import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.exception.DuplicatedUserException;
+import com.benchpress200.photique.user.domain.exception.UserNotFoundException;
+import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -215,6 +222,185 @@ public class UserCommandServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> userCommandService.resister(command)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 수정")
+    class UpdateUserDetailsTest {
+        @Test
+        @DisplayName("프로필 이미지 없이 처리에 성공한다")
+        public void whenCommandValidWithoutProfileImage() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder().build();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(outboxEvent).when(outboxEventFactory).userUpdated(any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+            // when
+            userCommandService.updateUserDetails(command);
+
+            // then
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(command.getUserId());
+            verify(imageUploaderPort, never()).upload(any(), any());
+            verify(outboxEventFactory).userUpdated(any());
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("새 프로필 이미지와 함께 처리에 성공한다")
+        public void whenCommandValidWithNewProfileImage() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            MultipartFile newProfileImage = mock(MultipartFile.class);
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder()
+                    .profileImage(newProfileImage)
+                    .build();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(false).when(newProfileImage).isEmpty();
+            doReturn("https://example.com/new-image.jpg").when(imageUploaderPort).upload(any(), any());
+            doReturn(outboxEvent).when(outboxEventFactory).userUpdated(any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+            // when
+            userCommandService.updateUserDetails(command);
+
+            // then
+            verify(userEventPublishPort).publishUserProfileImageDeleteEvent(any());
+            verify(imageUploaderPort).upload(any(), any());
+            verify(userEventPublishPort).publishUserProfileImageUploadEvent(any());
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("기본 이미지로 업데이트 시 처리에 성공한다")
+        public void whenCommandValidWithDefaultProfileImage() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            MultipartFile emptyProfileImage = mock(MultipartFile.class);
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder()
+                    .profileImage(emptyProfileImage)
+                    .build();
+            OutboxEvent outboxEvent = OutboxEventFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(true).when(emptyProfileImage).isEmpty();
+            doReturn(outboxEvent).when(outboxEventFactory).userUpdated(any());
+            doReturn(outboxEvent).when(outboxEventPort).save(any());
+
+            // when
+            userCommandService.updateUserDetails(command);
+
+            // then
+            verify(userEventPublishPort).publishUserProfileImageDeleteEvent(any());
+            verify(imageUploaderPort, never()).upload(any(), any());
+            verify(userEventPublishPort, never()).publishUserProfileImageUploadEvent(any());
+            verify(outboxEventPort).save(outboxEvent);
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 UserNotFoundException을 던진다")
+        public void whenUserNotFound() {
+            // given
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    UserNotFoundException.class,
+                    () -> userCommandService.updateUserDetails(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("프로필 이미지 삭제 이벤트 발행에 실패하면 예외를 던진다")
+        public void whenPublishDeleteEventFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            MultipartFile newProfileImage = mock(MultipartFile.class);
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder()
+                    .profileImage(newProfileImage)
+                    .build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doThrow(new RuntimeException()).when(userEventPublishPort).publishUserProfileImageDeleteEvent(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.updateUserDetails(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("이미지 업로드에 실패하면 예외를 던진다")
+        public void whenImageUploadFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            MultipartFile newProfileImage = mock(MultipartFile.class);
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder()
+                    .profileImage(newProfileImage)
+                    .build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(false).when(newProfileImage).isEmpty();
+            doThrow(new RuntimeException()).when(imageUploaderPort).upload(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.updateUserDetails(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("프로필 이미지 업로드 이벤트 발행에 실패하면 예외를 던진다")
+        public void whenPublishUploadEventFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            MultipartFile newProfileImage = mock(MultipartFile.class);
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder()
+                    .profileImage(newProfileImage)
+                    .build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(false).when(newProfileImage).isEmpty();
+            doReturn("https://example.com/new-image.jpg").when(imageUploaderPort).upload(any(), any());
+            doThrow(new RuntimeException()).when(userEventPublishPort).publishUserProfileImageUploadEvent(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.updateUserDetails(command)
+            );
+            verify(outboxEventPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("아웃박스 이벤트 저장에 실패하면 예외를 던진다")
+        public void whenOutboxEventSaveFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+            UserDetailsUpdateCommand command = UserDetailsUpdateCommandFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(null).when(outboxEventFactory).userUpdated(any());
+            doThrow(new RuntimeException()).when(outboxEventPort).save(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.updateUserDetails(command)
             );
         }
     }

--- a/src/test/java/com/benchpress200/photique/user/application/command/support/fixture/UserDetailsUpdateCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/user/application/command/support/fixture/UserDetailsUpdateCommandFixture.java
@@ -1,0 +1,49 @@
+package com.benchpress200.photique.user.application.command.support.fixture;
+
+import com.benchpress200.photique.user.application.command.model.UserDetailsUpdateCommand;
+import org.springframework.web.multipart.MultipartFile;
+
+public class UserDetailsUpdateCommandFixture {
+    private UserDetailsUpdateCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long userId = 1L;
+        private String nickname = "기본닉네임";
+        private String introduction = "기본소개";
+        private MultipartFile profileImage = null;
+
+        public Builder userId(Long userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder nickname(String nickname) {
+            this.nickname = nickname;
+            return this;
+        }
+
+        public Builder introduction(String introduction) {
+            this.introduction = introduction;
+            return this;
+        }
+
+        public Builder profileImage(MultipartFile profileImage) {
+            this.profileImage = profileImage;
+            return this;
+        }
+
+        public UserDetailsUpdateCommand build() {
+            return UserDetailsUpdateCommand.builder()
+                    .userId(userId)
+                    .nickname(nickname)
+                    .introduction(introduction)
+                    .profileImage(profileImage)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#289 요구에 따라서 UserCommandService.updateUserDetails()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 프로필 이미지 없이 처리에 성공하는 케이스
- 새 프로필 이미지와 함께 처리에 성공하는 케이스
- 기본 이미지로 업데이트 시 처리에 성공하는 케이스
- 유저가 존재하지 않는 경우 UserNotFoundException을 던지는 케이스
- 프로필 이미지 삭제 이벤트 발행에 실패하는 케이스
- 이미지 업로드에 실패하는 케이스
- 프로필 이미지 업로드 이벤트 발행에 실패하는 케이스
- 아웃박스 이벤트 저장에 실패하는 케이스

Closes #289