### PR TITLE
test(user): 유저 비밀번호 초기화 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
@@ -26,8 +26,10 @@ import com.benchpress200.photique.user.application.command.port.out.persistence.
 import com.benchpress200.photique.user.application.command.port.out.security.PasswordEncoderPort;
 import com.benchpress200.photique.user.application.command.service.UserCommandService;
 import com.benchpress200.photique.user.application.command.support.fixture.ResisterCommandFixture;
+import com.benchpress200.photique.user.application.command.model.UserPasswordResetCommand;
 import com.benchpress200.photique.user.application.command.model.UserPasswordUpdateCommand;
 import com.benchpress200.photique.user.application.command.support.fixture.UserDetailsUpdateCommandFixture;
+import com.benchpress200.photique.user.application.command.support.fixture.UserPasswordResetCommandFixture;
 import com.benchpress200.photique.user.application.command.support.fixture.UserPasswordUpdateCommandFixture;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
 import com.benchpress200.photique.user.domain.entity.User;
@@ -458,6 +460,104 @@ public class UserCommandServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> userCommandService.updateUserPassword(command)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 비밀번호 초기화")
+    class ResetUserPasswordTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenCommandValid() {
+            // given
+            User user = UserFixture.builder().build();
+            AuthMailCode authMailCode = AuthMailCodeFixture.builder().isVerified(true).build();
+            UserPasswordResetCommand command = UserPasswordResetCommandFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByEmailAndDeletedAtIsNull(any());
+            doReturn(Optional.of(authMailCode)).when(authMailCodeQueryPort).findById(any());
+            doReturn("encodedPassword").when(passwordEncoderPort).encode(any());
+
+            // when
+            userCommandService.resetUserPassword(command);
+
+            // then
+            verify(userQueryPort).findByEmailAndDeletedAtIsNull(command.getEmail());
+            verify(authMailCodeQueryPort).findById(command.getEmail());
+            verify(passwordEncoderPort).encode(command.getPassword());
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 UserNotFoundException을 던진다")
+        public void whenUserNotFound() {
+            // given
+            UserPasswordResetCommand command = UserPasswordResetCommandFixture.builder().build();
+
+            doReturn(Optional.empty()).when(userQueryPort).findByEmailAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    UserNotFoundException.class,
+                    () -> userCommandService.resetUserPassword(command)
+            );
+            verify(authMailCodeQueryPort, never()).findById(any());
+            verify(passwordEncoderPort, never()).encode(any());
+        }
+
+        @Test
+        @DisplayName("인증 코드가 만료되었으면 MailAuthenticationCodeExpirationException을 던진다")
+        public void whenAuthMailCodeExpired() {
+            // given
+            User user = UserFixture.builder().build();
+            UserPasswordResetCommand command = UserPasswordResetCommandFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByEmailAndDeletedAtIsNull(any());
+            doReturn(Optional.empty()).when(authMailCodeQueryPort).findById(any());
+
+            // when & then
+            assertThrows(
+                    MailAuthenticationCodeExpirationException.class,
+                    () -> userCommandService.resetUserPassword(command)
+            );
+            verify(passwordEncoderPort, never()).encode(any());
+        }
+
+        @Test
+        @DisplayName("인증이 완료되지 않은 코드이면 MailAuthenticationCodeNotVerifiedException을 던진다")
+        public void whenNotVerified() {
+            // given
+            User user = UserFixture.builder().build();
+            AuthMailCode authMailCode = AuthMailCodeFixture.builder().isVerified(false).build();
+            UserPasswordResetCommand command = UserPasswordResetCommandFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByEmailAndDeletedAtIsNull(any());
+            doReturn(Optional.of(authMailCode)).when(authMailCodeQueryPort).findById(any());
+
+            // when & then
+            assertThrows(
+                    MailAuthenticationCodeNotVerifiedException.class,
+                    () -> userCommandService.resetUserPassword(command)
+            );
+            verify(passwordEncoderPort, never()).encode(any());
+        }
+
+        @Test
+        @DisplayName("비밀번호 인코딩에 실패하면 예외를 던진다")
+        public void whenPasswordEncodeFails() {
+            // given
+            User user = UserFixture.builder().build();
+            AuthMailCode authMailCode = AuthMailCodeFixture.builder().isVerified(true).build();
+            UserPasswordResetCommand command = UserPasswordResetCommandFixture.builder().build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByEmailAndDeletedAtIsNull(any());
+            doReturn(Optional.of(authMailCode)).when(authMailCodeQueryPort).findById(any());
+            doThrow(new RuntimeException()).when(passwordEncoderPort).encode(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.resetUserPassword(command)
             );
         }
     }

--- a/src/test/java/com/benchpress200/photique/user/application/command/support/fixture/UserPasswordResetCommandFixture.java
+++ b/src/test/java/com/benchpress200/photique/user/application/command/support/fixture/UserPasswordResetCommandFixture.java
@@ -1,0 +1,34 @@
+package com.benchpress200.photique.user.application.command.support.fixture;
+
+import com.benchpress200.photique.user.application.command.model.UserPasswordResetCommand;
+
+public class UserPasswordResetCommandFixture {
+    private UserPasswordResetCommandFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String email = "test@example.com";
+        private String password = "기본비밀번호1!";
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public UserPasswordResetCommand build() {
+            return UserPasswordResetCommand.builder()
+                    .email(email)
+                    .password(password)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#291 요구에 따라서 UserCommandService.resetUserPassword()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공하는 케이스
- 유저가 존재하지 않는 경우 UserNotFoundException을 던지는 케이스
- 인증 코드가 만료된 경우 MailAuthenticationCodeExpirationException을 던지는 케이스
- 인증이 완료되지 않은 코드인 경우 MailAuthenticationCodeNotVerifiedException을 던지는 케이스
- 비밀번호 인코딩에 실패하는 케이스

Closes #291