### PR TITLE
test(user): 회원탈퇴 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/command/UserCommandServiceTest.java
@@ -561,4 +561,49 @@ public class UserCommandServiceTest extends BaseServiceTest {
             );
         }
     }
+
+    @Nested
+    @DisplayName("회원탈퇴")
+    class WithdrawTest {
+        @Test
+        @DisplayName("유저가 존재하면 소프트 딜리트 처리에 성공한다")
+        public void whenUserExists() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            userCommandService.withdraw(1L);
+
+            // then
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(1L);
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 아무 처리도 하지 않는다")
+        public void whenUserNotFound() {
+            // given
+            doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            userCommandService.withdraw(1L);
+
+            // then
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(1L);
+        }
+
+        @Test
+        @DisplayName("유저 조회에 실패하면 예외를 던진다")
+        public void whenFindUserFails() {
+            // given
+            doThrow(new RuntimeException()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userCommandService.withdraw(1L)
+            );
+        }
+    }
 }


### PR DESCRIPTION
# 목적
#292 요구에 따라서 UserCommandService.withdraw()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 유저가 존재하면 소프트 딜리트 처리에 성공하는 케이스
- 유저가 존재하지 않으면 아무 처리도 하지 않는 케이스
- 유저 조회에 실패하면 예외를 던지는 케이스

Closes #292