### PR TITLE
test(user): 유저 검색 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
@@ -1,0 +1,112 @@
+package com.benchpress200.photique.user.application.query;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
+import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkQueryPort;
+import com.benchpress200.photique.support.base.BaseServiceTest;
+import com.benchpress200.photique.user.application.query.model.UserSearchQuery;
+import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
+import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
+import com.benchpress200.photique.user.application.query.result.UserSearchResult;
+import com.benchpress200.photique.user.application.query.service.UserQueryService;
+import com.benchpress200.photique.user.application.query.support.fixture.UserSearchQueryFixture;
+import com.benchpress200.photique.user.domain.entity.User;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@DisplayName("유저 쿼리 서비스 테스트")
+public class UserQueryServiceTest extends BaseServiceTest {
+    @InjectMocks
+    private UserQueryService userQueryService;
+
+    @Mock
+    private AuthenticationUserProviderPort authenticationUserProviderPort;
+
+    @Mock
+    private UserQueryPort userQueryPort;
+
+    @Mock
+    private SingleWorkQueryPort singleWorkQueryPort;
+
+    @Mock
+    private ExhibitionQueryPort exhibitionQueryPort;
+
+    @Mock
+    private FollowQueryPort followQueryPort;
+
+    @Nested
+    @DisplayName("유저 검색")
+    class SearchUserTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            UserSearchQuery query = UserSearchQueryFixture.builder().build();
+            Page<User> userPage = new PageImpl<>(List.of(), PageRequest.of(0, 30), 0);
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(userPage).when(userQueryPort).findByNicknameStartingWithAndDeletedAtIsNull(any(), any());
+            doReturn(Set.of()).when(followQueryPort).findFolloweeIds(any(), any());
+
+            // when
+            UserSearchResult result = userQueryService.searchUser(query);
+
+            // then
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(userQueryPort).findByNicknameStartingWithAndDeletedAtIsNull(query.getKeyword(), query.getPageable());
+            verify(followQueryPort).findFolloweeIds(any(), any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("유저 검색에 실패하면 예외를 던진다")
+        public void whenSearchFails() {
+            // given
+            UserSearchQuery query = UserSearchQueryFixture.builder().build();
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doThrow(new RuntimeException()).when(userQueryPort).findByNicknameStartingWithAndDeletedAtIsNull(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.searchUser(query)
+            );
+            verify(followQueryPort, never()).findFolloweeIds(any(), any());
+        }
+
+        @Test
+        @DisplayName("팔로이 아이디 조회에 실패하면 예외를 던진다")
+        public void whenFindFolloweeIdsFails() {
+            // given
+            UserSearchQuery query = UserSearchQueryFixture.builder().build();
+            Page<User> userPage = new PageImpl<>(List.of(), PageRequest.of(0, 30), 0);
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(userPage).when(userQueryPort).findByNicknameStartingWithAndDeletedAtIsNull(any(), any());
+            doThrow(new RuntimeException()).when(followQueryPort).findFolloweeIds(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.searchUser(query)
+            );
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/user/application/query/support/fixture/UserSearchQueryFixture.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/support/fixture/UserSearchQueryFixture.java
@@ -1,0 +1,36 @@
+package com.benchpress200.photique.user.application.query.support.fixture;
+
+import com.benchpress200.photique.user.application.query.model.UserSearchQuery;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public class UserSearchQueryFixture {
+    private UserSearchQueryFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String keyword = "기본 키워드";
+        private Pageable pageable = PageRequest.of(0, 30);
+
+        public Builder keyword(String keyword) {
+            this.keyword = keyword;
+            return this;
+        }
+
+        public Builder pageable(Pageable pageable) {
+            this.pageable = pageable;
+            return this;
+        }
+
+        public UserSearchQuery build() {
+            return UserSearchQuery.builder()
+                    .keyword(keyword)
+                    .pageable(pageable)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#298 요구에 따라서 UserQueryService.searchUser()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 유저 검색에 실패하면 예외를 던진다
- 팔로이 아이디 조회에 실패하면 예외를 던진다

Closes #298