### PR TITLE
test(user): 내 정보 상세 조회 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
@@ -15,11 +15,15 @@ import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.user.application.query.model.UserSearchQuery;
 import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
+import com.benchpress200.photique.user.application.query.result.MyDetailsResult;
 import com.benchpress200.photique.user.application.query.result.UserSearchResult;
 import com.benchpress200.photique.user.application.query.service.UserQueryService;
 import com.benchpress200.photique.user.application.query.support.fixture.UserSearchQueryFixture;
 import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.exception.UserNotFoundException;
+import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -106,6 +110,128 @@ public class UserQueryServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> userQueryService.searchUser(query)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("내 정보 상세 조회")
+    class GetMyDetailsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(user.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doReturn(0L).when(followQueryPort).countByFollowee(any());
+            doReturn(0L).when(followQueryPort).countByFollower(any());
+
+            // when
+            MyDetailsResult result = userQueryService.getMyDetails();
+
+            // then
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(user.getId());
+            verify(singleWorkQueryPort).countByWriter(user);
+            verify(exhibitionQueryPort).countByWriter(user);
+            verify(followQueryPort).countByFollowee(user);
+            verify(followQueryPort).countByFollower(user);
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 UserNotFoundException을 던진다")
+        public void whenUserNotFound() {
+            // given
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    UserNotFoundException.class,
+                    () -> userQueryService.getMyDetails()
+            );
+            verify(singleWorkQueryPort, never()).countByWriter(any());
+        }
+
+        @Test
+        @DisplayName("단일작품 카운팅에 실패하면 예외를 던진다")
+        public void whenCountSingleWorkFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(user.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doThrow(new RuntimeException()).when(singleWorkQueryPort).countByWriter(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getMyDetails()
+            );
+            verify(exhibitionQueryPort, never()).countByWriter(any());
+        }
+
+        @Test
+        @DisplayName("전시회 카운팅에 실패하면 예외를 던진다")
+        public void whenCountExhibitionFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(user.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doThrow(new RuntimeException()).when(exhibitionQueryPort).countByWriter(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getMyDetails()
+            );
+            verify(followQueryPort, never()).countByFollowee(any());
+        }
+
+        @Test
+        @DisplayName("팔로워 카운팅에 실패하면 예외를 던진다")
+        public void whenCountFollowerFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(user.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doThrow(new RuntimeException()).when(followQueryPort).countByFollowee(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getMyDetails()
+            );
+            verify(followQueryPort, never()).countByFollower(any());
+        }
+
+        @Test
+        @DisplayName("팔로잉 카운팅에 실패하면 예외를 던진다")
+        public void whenCountFollowingFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(user.getId()).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doReturn(0L).when(followQueryPort).countByFollowee(any());
+            doThrow(new RuntimeException()).when(followQueryPort).countByFollower(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getMyDetails()
             );
         }
     }


### PR DESCRIPTION
# 목적
#297 요구에 따라서 UserQueryService.getMyDetails()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 유저가 존재하지 않으면 UserNotFoundException을 던진다
- 단일작품 카운팅에 실패하면 예외를 던진다
- 전시회 카운팅에 실패하면 예외를 던진다
- 팔로워 카운팅에 실패하면 예외를 던진다
- 팔로잉 카운팅에 실패하면 예외를 던진다

Closes #297