### PR TITLE
test(user): 유저 정보 상세 조회 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/UserQueryServiceTest.java
@@ -16,6 +16,7 @@ import com.benchpress200.photique.user.application.query.model.UserSearchQuery;
 import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
 import com.benchpress200.photique.user.application.query.result.MyDetailsResult;
+import com.benchpress200.photique.user.application.query.result.UserDetailsResult;
 import com.benchpress200.photique.user.application.query.result.UserSearchResult;
 import com.benchpress200.photique.user.application.query.service.UserQueryService;
 import com.benchpress200.photique.user.application.query.support.fixture.UserSearchQueryFixture;
@@ -232,6 +233,147 @@ public class UserQueryServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> userQueryService.getMyDetails()
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 정보 상세 조회")
+    class GetUserDetailsTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doReturn(0L).when(followQueryPort).countByFollowee(any());
+            doReturn(0L).when(followQueryPort).countByFollower(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(false).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+
+            // when
+            UserDetailsResult result = userQueryService.getUserDetails(user.getId());
+
+            // then
+            verify(userQueryPort).findByIdAndDeletedAtIsNull(user.getId());
+            verify(singleWorkQueryPort).countByWriter(user);
+            verify(exhibitionQueryPort).countByWriter(user);
+            verify(followQueryPort).countByFollowee(user);
+            verify(followQueryPort).countByFollower(user);
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 UserNotFoundException을 던진다")
+        public void whenUserNotFound() {
+            // given
+            doReturn(Optional.empty()).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when & then
+            assertThrows(
+                    UserNotFoundException.class,
+                    () -> userQueryService.getUserDetails(1L)
+            );
+            verify(singleWorkQueryPort, never()).countByWriter(any());
+        }
+
+        @Test
+        @DisplayName("단일작품 카운팅에 실패하면 예외를 던진다")
+        public void whenCountSingleWorkFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doThrow(new RuntimeException()).when(singleWorkQueryPort).countByWriter(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getUserDetails(user.getId())
+            );
+            verify(exhibitionQueryPort, never()).countByWriter(any());
+        }
+
+        @Test
+        @DisplayName("전시회 카운팅에 실패하면 예외를 던진다")
+        public void whenCountExhibitionFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doThrow(new RuntimeException()).when(exhibitionQueryPort).countByWriter(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getUserDetails(user.getId())
+            );
+            verify(followQueryPort, never()).countByFollowee(any());
+        }
+
+        @Test
+        @DisplayName("팔로워 카운팅에 실패하면 예외를 던진다")
+        public void whenCountFollowerFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doThrow(new RuntimeException()).when(followQueryPort).countByFollowee(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getUserDetails(user.getId())
+            );
+            verify(followQueryPort, never()).countByFollower(any());
+        }
+
+        @Test
+        @DisplayName("팔로잉 카운팅에 실패하면 예외를 던진다")
+        public void whenCountFollowingFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doReturn(0L).when(followQueryPort).countByFollowee(any());
+            doThrow(new RuntimeException()).when(followQueryPort).countByFollower(any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getUserDetails(user.getId())
+            );
+            verify(authenticationUserProviderPort, never()).getCurrentUserId();
+        }
+
+        @Test
+        @DisplayName("팔로우 여부 조회에 실패하면 예외를 던진다")
+        public void whenCheckFollowingFails() {
+            // given
+            User user = UserFixture.builder().id(1L).build();
+
+            doReturn(Optional.of(user)).when(userQueryPort).findByIdAndDeletedAtIsNull(any());
+            doReturn(0L).when(singleWorkQueryPort).countByWriter(any());
+            doReturn(0L).when(exhibitionQueryPort).countByWriter(any());
+            doReturn(0L).when(followQueryPort).countByFollowee(any());
+            doReturn(0L).when(followQueryPort).countByFollower(any());
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doThrow(new RuntimeException()).when(followQueryPort).existsByFollowerIdAndFolloweeId(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> userQueryService.getUserDetails(user.getId())
             );
         }
     }


### PR DESCRIPTION
# 목적
#296 요구에 따라서 UserQueryService.getUserDetails()에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 유저가 존재하지 않으면 UserNotFoundException을 던진다
- 단일작품 카운팅에 실패하면 예외를 던진다
- 전시회 카운팅에 실패하면 예외를 던진다
- 팔로워 카운팅에 실패하면 예외를 던진다
- 팔로잉 카운팅에 실패하면 예외를 던진다
- 팔로우 여부 조회에 실패하면 예외를 던진다

Closes #296