### PR TITLE
test(user): 팔로워 검색 유스케이스 단위 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/user/application/query/FollowQueryServiceTest.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/FollowQueryServiceTest.java
@@ -11,10 +11,13 @@ import static org.mockito.Mockito.verify;
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationUserProviderPort;
 import com.benchpress200.photique.support.base.BaseServiceTest;
 import com.benchpress200.photique.user.application.query.model.FolloweeSearchQuery;
+import com.benchpress200.photique.user.application.query.model.FollowerSearchQuery;
 import com.benchpress200.photique.user.application.query.port.out.persistence.FollowQueryPort;
 import com.benchpress200.photique.user.application.query.result.FolloweeSearchResult;
+import com.benchpress200.photique.user.application.query.result.FollowerSearchResult;
 import com.benchpress200.photique.user.application.query.service.FollowQueryService;
 import com.benchpress200.photique.user.application.query.support.fixture.FolloweeSearchQueryFixture;
+import com.benchpress200.photique.user.application.query.support.fixture.FollowerSearchQueryFixture;
 import com.benchpress200.photique.user.domain.entity.User;
 import java.util.List;
 import java.util.Set;
@@ -94,6 +97,66 @@ public class FollowQueryServiceTest extends BaseServiceTest {
             assertThrows(
                     RuntimeException.class,
                     () -> followQueryService.searchFollowee(query)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("팔로워 검색")
+    class SearchFollowerTest {
+        @Test
+        @DisplayName("처리에 성공한다")
+        public void whenQueryValid() {
+            // given
+            FollowerSearchQuery query = FollowerSearchQueryFixture.builder().build();
+            Page<User> followerPage = new PageImpl<>(List.of(), PageRequest.of(0, 30), 0);
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(followerPage).when(followQueryPort).searchFollower(any(), any(), any());
+            doReturn(Set.of()).when(followQueryPort).findFolloweeIds(any(), any());
+
+            // when
+            FollowerSearchResult result = followQueryService.searchFollower(query);
+
+            // then
+            verify(authenticationUserProviderPort).getCurrentUserId();
+            verify(followQueryPort).searchFollower(query.getUserId(), query.getKeyword(), query.getPageable());
+            verify(followQueryPort).findFolloweeIds(any(), any());
+            assertNotNull(result);
+        }
+
+        @Test
+        @DisplayName("팔로워 검색에 실패하면 예외를 던진다")
+        public void whenSearchFollowerFails() {
+            // given
+            FollowerSearchQuery query = FollowerSearchQueryFixture.builder().build();
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doThrow(new RuntimeException()).when(followQueryPort).searchFollower(any(), any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> followQueryService.searchFollower(query)
+            );
+            verify(followQueryPort, never()).findFolloweeIds(any(), any());
+        }
+
+        @Test
+        @DisplayName("팔로이 아이디 조회에 실패하면 예외를 던진다")
+        public void whenFindFolloweeIdsFails() {
+            // given
+            FollowerSearchQuery query = FollowerSearchQueryFixture.builder().build();
+            Page<User> followerPage = new PageImpl<>(List.of(), PageRequest.of(0, 30), 0);
+
+            doReturn(1L).when(authenticationUserProviderPort).getCurrentUserId();
+            doReturn(followerPage).when(followQueryPort).searchFollower(any(), any(), any());
+            doThrow(new RuntimeException()).when(followQueryPort).findFolloweeIds(any(), any());
+
+            // when & then
+            assertThrows(
+                    RuntimeException.class,
+                    () -> followQueryService.searchFollower(query)
             );
         }
     }

--- a/src/test/java/com/benchpress200/photique/user/application/query/support/fixture/FollowerSearchQueryFixture.java
+++ b/src/test/java/com/benchpress200/photique/user/application/query/support/fixture/FollowerSearchQueryFixture.java
@@ -1,0 +1,43 @@
+package com.benchpress200.photique.user.application.query.support.fixture;
+
+import com.benchpress200.photique.user.application.query.model.FollowerSearchQuery;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+public class FollowerSearchQueryFixture {
+    private FollowerSearchQueryFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long userId = 1L;
+        private String keyword = "기본 키워드";
+        private Pageable pageable = PageRequest.of(0, 30);
+
+        public Builder userId(Long userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder keyword(String keyword) {
+            this.keyword = keyword;
+            return this;
+        }
+
+        public Builder pageable(Pageable pageable) {
+            this.pageable = pageable;
+            return this;
+        }
+
+        public FollowerSearchQuery build() {
+            return FollowerSearchQuery.builder()
+                    .userId(userId)
+                    .keyword(keyword)
+                    .pageable(pageable)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
# 목적
#293 요구에 따라서 FollowQueryService.searchFollower() 메서드에 대한 단위 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 처리에 성공한다
- 팔로워 검색에 실패하면 예외를 던진다
- 팔로이 아이디 조회에 실패하면 예외를 던진다

Closes #293