### PR TITLE
test(auth): 비밀번호 초기화 인증 메일 전송 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
@@ -155,6 +155,121 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("비밀번호 초기화 인증 메일 전송")
+    class SendPasswordAuthMailTest {
+        @Test
+        @DisplayName("요청이 유효하면 인증 코드를 저장하고 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            AuthMailRequest request = AuthMailRequestFixture.builder().build();
+            String email = request.getEmail();
+
+            User user = UserFixture.builder()
+                    .email(email)
+                    .build();
+
+            userCommandPort.save(user);
+
+            // when
+            ResultActions resultActions = requestSendPasswordAuthMail(request);
+            Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(email);
+
+            // then
+            resultActions.andExpect(status().isCreated());
+            Assertions.assertThat(authMailCode)
+                    .isPresent()
+                    .get()
+                    .satisfies(code -> {
+                        Assertions.assertThat(code.getEmail()).isEqualTo(email);
+                        Assertions.assertThat(code.isVerified()).isFalse();
+                    });
+        }
+
+        @ParameterizedTest
+        @DisplayName("이메일이 유효하지 않으면 인증 코드를 저장하지 않고 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.auth.AuthCommandIntegrationTest#invalidEmails")
+        public void whenEmailInvalid(String invalidEmail) throws Exception {
+            // given
+            AuthMailRequest request = AuthMailRequestFixture.builder()
+                    .email(invalidEmail)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestSendPasswordAuthMail(request);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+            if (invalidEmail != null) {
+                Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(invalidEmail);
+                Assertions.assertThat(authMailCode).isNotPresent();
+            }
+        }
+
+        @Test
+        @DisplayName("가입되지 않은 이메일이면 인증 코드를 저장하지 않고 404를 반환한다")
+        public void whenEmailNotFound() throws Exception {
+            // given
+            AuthMailRequest request = AuthMailRequestFixture.builder().build();
+            String email = request.getEmail();
+
+            // when
+            ResultActions resultActions = requestSendPasswordAuthMail(request);
+            Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(email);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+            Assertions.assertThat(authMailCode).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("메일 전송에 실패하면 인증 코드를 저장하지 않고 500을 반환한다")
+        public void whenMailSendFails() throws Exception {
+            // given
+            AuthMailRequest request = AuthMailRequestFixture.builder().build();
+            String email = request.getEmail();
+
+            User user = UserFixture.builder()
+                    .email(email)
+                    .build();
+
+            userCommandPort.save(user);
+
+            Mockito.doThrow(new MailSendException("메일 전송 실패")).when(mailSenderPort).sendMail(any());
+
+            // when
+            ResultActions resultActions = requestSendPasswordAuthMail(request);
+            Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(email);
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(authMailCode).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("인증 코드 저장에 실패하면 500을 반환한다")
+        public void whenSaveFails() throws Exception {
+            // given
+            AuthMailRequest request = AuthMailRequestFixture.builder().build();
+            String email = request.getEmail();
+
+            User user = UserFixture.builder()
+                    .email(email)
+                    .build();
+
+            userCommandPort.save(user);
+
+            Mockito.doThrow(new DataAccessResourceFailureException("Redis 에러"))
+                    .when(authMailCodeCommandPort).save(any());
+
+            // when
+            ResultActions resultActions = requestSendPasswordAuthMail(request);
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+        }
+    }
+
     private static Stream<String> invalidEmails() {
         return Stream.of(
                 null,           // @NotNull 위반
@@ -165,6 +280,14 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
     private ResultActions requestSendJoinAuthMail(AuthMailRequest request) throws Exception {
         return mockMvc.perform(
                 post(ApiPath.AUTH_MAIL_JOIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    private ResultActions requestSendPasswordAuthMail(AuthMailRequest request) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.AUTH_MAIL_PASSWORD)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
         );


### PR DESCRIPTION
# 목적
#283 요구에 따라서 AuthCommandController.sendPasswordAuthMail() API에 대한 통합 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청이 유효하면 인증 코드를 저장하고 201을 반환한다
- 이메일이 유효하지 않으면 인증 코드를 저장하지 않고 400을 반환한다
- 가입되지 않은 이메일이면 인증 코드를 저장하지 않고 404를 반환한다
- 메일 전송에 실패하면 인증 코드를 저장하지 않고 500을 반환한다
- 인증 코드 저장에 실패하면 500을 반환한다

Closes #283