### PR TITLE
test: 통합테스트 케이스에서 최종 영속화 정상 확인을 위한 수정

### DIFF
--- a/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionCommandPort.java
@@ -10,4 +10,6 @@ public interface ExhibitionCommandPort {
     void incrementLikeCount(Long exhibitionId);
 
     void decrementLikeCount(Long exhibitionId);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionTagCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionTagCommandPort.java
@@ -10,4 +10,6 @@ public interface ExhibitionTagCommandPort {
     List<ExhibitionTag> saveAll(List<ExhibitionTag> exhibitionTags);
 
     void deleteByExhibition(Exhibition exhibition);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionWorkCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionWorkCommandPort.java
@@ -4,4 +4,6 @@ import com.benchpress200.photique.exhibition.domain.entity.ExhibitionWork;
 
 public interface ExhibitionWorkCommandPort {
     ExhibitionWork save(ExhibitionWork work);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionPersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionPersistenceAdapter.java
@@ -70,4 +70,9 @@ public class ExhibitionPersistenceAdapter implements
     public void decrementLikeCount(Long exhibitionId) {
         exhibitionRepository.decrementLikeCount(exhibitionId);
     }
+
+    @Override
+    public void deleteAll() {
+        exhibitionRepository.deleteAll();
+    }
 }

--- a/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionTagPersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionTagPersistenceAdapter.java
@@ -34,6 +34,11 @@ public class ExhibitionTagPersistenceAdapter implements
     }
 
     @Override
+    public void deleteAll() {
+        exhibitionTagRepository.deleteAll();
+    }
+
+    @Override
     public List<ExhibitionTag> findByExhibitionWithTag(Exhibition exhibition) {
         return exhibitionTagRepository.findByExhibitionWithTag(exhibition);
     }

--- a/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionWorkPersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionWorkPersistenceAdapter.java
@@ -24,6 +24,11 @@ public class ExhibitionWorkPersistenceAdapter implements
     }
 
     @Override
+    public void deleteAll() {
+        exhibitionWorkRepository.deleteAll();
+    }
+
+    @Override
     public Optional<ExhibitionWork> findById(Long id) {
         return exhibitionWorkRepository.findById(id);
     }

--- a/src/main/java/com/benchpress200/photique/user/application/command/port/out/persistence/UserCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/user/application/command/port/out/persistence/UserCommandPort.java
@@ -4,4 +4,6 @@ import com.benchpress200.photique.user.domain.entity.User;
 
 public interface UserCommandPort {
     User save(User user);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/user/infrastructure/persistence/adapter/UserPersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/user/infrastructure/persistence/adapter/UserPersistenceAdapter.java
@@ -23,6 +23,11 @@ public class UserPersistenceAdapter implements
     }
 
     @Override
+    public void deleteAll() {
+        userRepository.deleteAll();
+    }
+
+    @Override
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);
     }

--- a/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
@@ -49,6 +49,7 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        userCommandPort.deleteAll();
         authMailCodeCommandPort.deleteAll();
         Mockito.doNothing().when(mailSenderPort).sendMail(any());
     }

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommandIntegrationTest.java
@@ -79,6 +79,11 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        exhibitionTagCommandPort.deleteAll();
+        exhibitionWorkCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
+
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -261,6 +266,7 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
         }
 
         @Test
@@ -317,6 +323,7 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
         }
 
         @Test
@@ -334,6 +341,7 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
         }
 
         @Test
@@ -351,6 +359,7 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
@@ -55,6 +55,7 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void cleanAuthMailCode() {
         authMailCodeCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested

--- a/src/test/java/com/benchpress200/photique/support/base/BaseIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/support/base/BaseIntegrationTest.java
@@ -2,7 +2,6 @@ package com.benchpress200.photique.support.base;
 
 import com.benchpress200.photique.constant.Profile;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,7 +10,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@Transactional
 @ActiveProfiles(Profile.TEST)
 public abstract class BaseIntegrationTest extends BaseTestContainerTest {
     @Autowired


### PR DESCRIPTION
# 목적
통합테스트 케이스에서 데이터 영속화 상태 확인을 위한 관련 코드 수정
# 작업 내용 
통합 테스트 코드에서 테스트 컨테이너를 활용하여 영속 상태를 확인합니다. 추상 클래스 `BaseIntegrationTest`의 `@Transational`로 인해 내부 서비스 로직의 트랜잭션이 병합되어, 롤백 시점이 늦어져 데이터 롤백 여부를 코드로 체크할 수 없었습니다.<br>
따라서, `BaseIntegrationTest`의 `@Transactional`을 제거하고 각 테스트 클래스에서 클린업 작업을 진행한 후 데이터의 저장, 롤백 상태 등을 검증할 수 있도록 수정했습니다.