### PR TITLE
test(notification): 알림 읽음 처리 API 통합 테스트 코드 작성

### DIFF
--- a/src/main/java/com/benchpress200/photique/notification/application/command/port/out/persistence/NotificationCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/notification/application/command/port/out/persistence/NotificationCommandPort.java
@@ -9,4 +9,6 @@ public interface NotificationCommandPort {
     List<Notification> saveAll(List<Notification> notifications);
 
     void markAllAsReadByReceiverIdAndDeletedAtIsNull(Long receiverId);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/notification/domain/entity/Notification.java
+++ b/src/main/java/com/benchpress200/photique/notification/domain/entity/Notification.java
@@ -64,11 +64,13 @@ public class Notification {
     public Notification(
             User receiver,
             NotificationType type,
-            Long targetId
+            Long targetId,
+            Long eventId
     ) {
         this.receiver = receiver;
         this.type = type;
         this.targetId = targetId;
+        this.eventId = eventId;
     }
 
     public void read() {

--- a/src/main/java/com/benchpress200/photique/notification/infrastructure/persistence/adapter/NotificationPersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/notification/infrastructure/persistence/adapter/NotificationPersistenceAdapter.java
@@ -47,4 +47,9 @@ public class NotificationPersistenceAdapter implements
     public Optional<Notification> findByIdAndDeletedAtIsNull(Long id) {
         return notificationRepository.findByIdAndDeletedAtIsNull(id);
     }
+
+    @Override
+    public void deleteAll() {
+        notificationRepository.deleteAll();
+    }
 }

--- a/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.benchpress200.photique.integration.notification;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,8 +21,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("알림 커맨드 API 통합 테스트")
@@ -30,7 +34,7 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private NotificationCommandPort notificationCommandPort;
 
-    @Autowired
+    @MockitoSpyBean
     private NotificationQueryPort notificationQueryPort;
 
     @Autowired
@@ -120,6 +124,35 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("알림 조회 중 DB 예외가 발생하면 500을 반환한다")
+        public void whenQueryFails() throws Exception {
+            // given
+            Notification savedNotification = notificationCommandPort.save(
+                    NotificationFixture.builder()
+                            .receiver(savedUser)
+                            .build()
+            );
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            ResultActions resultActions = requestMarkAsReadAuthenticated(savedNotification.getId());
+
+            // 스파이 복원 후 DB 상태 검증
+            Mockito.doCallRealMethod().when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
+            Optional<Notification> notification = notificationQueryPort.findByIdAndDeletedAtIsNull(
+                    savedNotification.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(notification)
+                    .isPresent()
+                    .get()
+                    .satisfies(n -> Assertions.assertThat(n.isRead()).isFalse());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.benchpress200.photique.integration.notification;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
+import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.notification.application.command.port.out.persistence.NotificationCommandPort;
+import com.benchpress200.photique.notification.application.query.port.out.persistence.NotificationQueryPort;
+import com.benchpress200.photique.notification.domain.entity.Notification;
+import com.benchpress200.photique.notification.domain.support.NotificationFixture;
+import com.benchpress200.photique.support.base.BaseIntegrationTest;
+import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("알림 커맨드 API 통합 테스트")
+public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private NotificationCommandPort notificationCommandPort;
+
+    @Autowired
+    private NotificationQueryPort notificationQueryPort;
+
+    @Autowired
+    private UserCommandPort userCommandPort;
+
+    @Autowired
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    private User savedUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        notificationCommandPort.deleteAll();
+        userCommandPort.deleteAll();
+
+        User user = UserFixture.builder().build();
+        savedUser = userCommandPort.save(user);
+
+        AuthenticationTokens tokens = authenticationTokenManagerPort.issueTokens(
+                savedUser.getId(),
+                savedUser.getRole().name()
+        );
+        accessToken = tokens.getAccessToken();
+    }
+
+    @Nested
+    @DisplayName("알림 읽음 처리")
+    class MarkAsReadTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 알림을 읽음 처리하고 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Notification savedNotification = notificationCommandPort.save(
+                    NotificationFixture.builder()
+                            .receiver(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestMarkAsReadAuthenticated(savedNotification.getId());
+            Optional<Notification> notification = notificationQueryPort.findByIdAndDeletedAtIsNull(
+                    savedNotification.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isNoContent());
+            Assertions.assertThat(notification)
+                    .isPresent()
+                    .get()
+                    .satisfies(n -> Assertions.assertThat(n.isRead()).isTrue());
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            Notification savedNotification = notificationCommandPort.save(
+                    NotificationFixture.builder()
+                            .receiver(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestMarkAsRead(savedNotification.getId());
+            Optional<Notification> notification = notificationQueryPort.findByIdAndDeletedAtIsNull(
+                    savedNotification.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+            Assertions.assertThat(notification)
+                    .isPresent()
+                    .get()
+                    .satisfies(n -> Assertions.assertThat(n.isRead()).isFalse());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림이면 404를 반환한다")
+        public void whenNotificationNotFound() throws Exception {
+            // given
+            Long nonExistentId = 9999L;
+
+            // when
+            ResultActions resultActions = requestMarkAsReadAuthenticated(nonExistentId);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+    }
+
+    private ResultActions requestMarkAsRead(Long notificationId) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.NOTIFICATION_DATA, notificationId)
+        );
+    }
+
+    private ResultActions requestMarkAsReadAuthenticated(Long notificationId) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.NOTIFICATION_DATA, notificationId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
+    }
+}

--- a/src/test/java/com/benchpress200/photique/notification/domain/support/NotificationFixture.java
+++ b/src/test/java/com/benchpress200/photique/notification/domain/support/NotificationFixture.java
@@ -17,6 +17,7 @@ public class NotificationFixture {
         private User receiver = UserFixture.builder().id(1L).build();
         private NotificationType type = NotificationType.FOLLOW;
         private Long targetId = 1L;
+        private Long eventId = 1L;
 
         public Builder receiver(User receiver) {
             this.receiver = receiver;
@@ -33,11 +34,17 @@ public class NotificationFixture {
             return this;
         }
 
+        public Builder eventId(Long eventId) {
+            this.eventId = eventId;
+            return this;
+        }
+
         public Notification build() {
             return Notification.builder()
                     .receiver(receiver)
                     .type(type)
                     .targetId(targetId)
+                    .eventId(eventId)
                     .build();
         }
     }


### PR DESCRIPTION
# 목적
#262 요구에 따라서 NotificationCommandController.markAsRead()에 대한 통합 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청이 유효하면 알림을 읽음 처리하고 204를 반환한다
- 인증 토큰이 없으면 401을 반환한다
- 존재하지 않는 알림이면 404를 반환한다

Closes #262