### PR TITLE
test(exhibition): 전시회 좋아요 추가 API 통합 테스트 코드 작성

### DIFF
--- a/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionLikeCommandPort.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/command/port/out/ExhibitionLikeCommandPort.java
@@ -6,4 +6,6 @@ public interface ExhibitionLikeCommandPort {
     ExhibitionLike save(ExhibitionLike exhibitionLike);
 
     void delete(ExhibitionLike exhibitionLike);
+
+    void deleteAll();
 }

--- a/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionLikePersistenceAdapter.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/infrastructure/persistence/adapter/ExhibitionLikePersistenceAdapter.java
@@ -54,4 +54,9 @@ public class ExhibitionLikePersistenceAdapter implements
     public void delete(ExhibitionLike exhibitionLike) {
         exhibitionLikeRepository.delete(exhibitionLike);
     }
+
+    @Override
+    public void deleteAll() {
+        exhibitionLikeRepository.deleteAll();
+    }
 }

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeCommandIntegrationTest.java
@@ -1,0 +1,245 @@
+package com.benchpress200.photique.integration.exhibition;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
+import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionLikeCommandPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionLikeQueryPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
+import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionLike;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
+import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
+import com.benchpress200.photique.support.base.BaseIntegrationTest;
+import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("전시회 좋아요 커맨드 API 통합 테스트")
+public class ExhibitionLikeCommandIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UserCommandPort userCommandPort;
+
+    @Autowired
+    private ExhibitionLikeQueryPort exhibitionLikeQueryPort;
+
+    @Autowired
+    private ExhibitionQueryPort exhibitionQueryPort;
+
+    @Autowired
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    @MockitoSpyBean
+    private ExhibitionCommandPort exhibitionCommandPort;
+
+    @MockitoSpyBean
+    private ExhibitionLikeCommandPort exhibitionLikeCommandPort;
+
+    @MockitoSpyBean
+    private OutboxEventPort outboxEventPort;
+
+    private User savedUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        exhibitionLikeCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
+
+        User user = UserFixture.builder().build();
+        savedUser = userCommandPort.save(user);
+
+        AuthenticationTokens tokens = authenticationTokenManagerPort.issueTokens(
+                savedUser.getId(),
+                savedUser.getRole().name()
+        );
+        accessToken = tokens.getAccessToken();
+    }
+
+    @Nested
+    @DisplayName("전시회 좋아요 추가")
+    class AddExhibitionLikeTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 좋아요를 저장하고 201을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
+            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
+                    savedUser.getId(),
+                    exhibition.getId()
+            );
+            long likeCount = exhibitionQueryPort.findByIdAndDeletedAtIsNull(exhibition.getId())
+                    .orElseThrow()
+                    .getLikeCount();
+
+            // then
+            resultActions.andExpect(status().isCreated());
+            Assertions.assertThat(exists).isTrue();
+            Assertions.assertThat(likeCount).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLike(exhibition.getId());
+            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
+                    savedUser.getId(),
+                    exhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+            Assertions.assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 전시회이면 404를 반환한다")
+        public void whenExhibitionNotFound() throws Exception {
+            // given
+            Long nonExistentId = 9999L;
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(nonExistentId);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("이미 좋아요한 전시회이면 409를 반환한다")
+        public void whenAlreadyLiked() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            exhibitionLikeCommandPort.save(ExhibitionLike.of(savedUser, exhibition));
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
+
+            // then
+            resultActions.andExpect(status().isConflict());
+        }
+
+        @Test
+        @DisplayName("좋아요 저장에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
+        public void whenLikeSaveFails() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(exhibitionLikeCommandPort).save(any());
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
+            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
+                    savedUser.getId(),
+                    exhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("좋아요 수 증가에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
+        public void whenIncrementLikeCountFails() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(exhibitionCommandPort).incrementLikeCount(any());
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
+            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
+                    savedUser.getId(),
+                    exhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("아웃박스 이벤트 저장에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
+        public void whenOutboxSaveFails() throws Exception {
+            // given
+            Exhibition exhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(outboxEventPort).save(any());
+
+            // when
+            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
+            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
+                    savedUser.getId(),
+                    exhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(exists).isFalse();
+        }
+    }
+
+    private ResultActions requestAddExhibitionLike(Long exhibitionId) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.EXHIBITION_LIKE, exhibitionId)
+        );
+    }
+
+    private ResultActions requestAddExhibitionLikeAuthenticated(Long exhibitionId) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.EXHIBITION_LIKE, exhibitionId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
+    }
+}


### PR DESCRIPTION
# 목적
#274 요구에 따라서 ExhibitionLikeCommandController.addExhibitionLike()에 대한 통합 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 좋아요 추가 요청 성공
- 인증 토큰 없이 요청
- 존재하지 않는 전시회에 요청
- 이미 좋아요한 전시회에 요청
- 좋아요 저장 중 DB 예외 발생
- 좋아요 수 증가 중 DB 예외 발생
- 아웃박스 이벤트 저장 중 DB 예외 발생

Closes #274