### PR TITLE
test(notification): 알림 페이지 조회 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionBookmarkCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionBookmarkCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,15 +18,13 @@ import com.benchpress200.photique.user.application.command.port.out.persistence.
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("전시회 북마크 커맨드 API 통합 테스트")
@@ -42,10 +39,10 @@ public class ExhibitionBookmarkCommandIntegrationTest extends BaseIntegrationTes
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionBookmarkCommandPort exhibitionBookmarkCommandPort;
 
     private User savedUser;
@@ -53,10 +50,6 @@ public class ExhibitionBookmarkCommandIntegrationTest extends BaseIntegrationTes
 
     @BeforeEach
     void setUp() {
-        exhibitionBookmarkCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -65,6 +58,13 @@ public class ExhibitionBookmarkCommandIntegrationTest extends BaseIntegrationTes
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionBookmarkCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -144,30 +144,6 @@ public class ExhibitionBookmarkCommandIntegrationTest extends BaseIntegrationTes
 
             // then
             resultActions.andExpect(status().isConflict());
-        }
-
-        @Test
-        @DisplayName("북마크 저장에 실패하면 북마크를 저장하지 않고 500을 반환한다")
-        public void whenBookmarkSaveFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionBookmarkCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestAddExhibitionBookmarkAuthenticated(exhibition.getId());
-            boolean exists = exhibitionBookmarkQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    exhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exists).isFalse();
         }
     }
 
@@ -249,31 +225,6 @@ public class ExhibitionBookmarkCommandIntegrationTest extends BaseIntegrationTes
 
             // then
             resultActions.andExpect(status().isNoContent());
-        }
-
-        @Test
-        @DisplayName("북마크 삭제 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenBookmarkDeleteFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            exhibitionBookmarkCommandPort.save(ExhibitionBookmark.of(savedUser, exhibition));
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionBookmarkCommandPort).delete(any());
-
-            // when
-            ResultActions resultActions = requestCancelExhibitionBookmarkAuthenticated(exhibition.getId());
-            boolean exists = exhibitionBookmarkQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    exhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exists).isTrue();
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionBookmarkQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionBookmarkQueryIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,7 +9,6 @@ import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionBookmarkCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
-import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionBookmarkQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.entity.ExhibitionBookmark;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
@@ -18,15 +16,13 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -39,24 +35,17 @@ public class ExhibitionBookmarkQueryIntegrationTest extends BaseIntegrationTest 
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionBookmarkCommandPort exhibitionBookmarkCommandPort;
-
-    @MockitoSpyBean
-    private ExhibitionBookmarkQueryPort exhibitionBookmarkQueryPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionBookmarkCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -65,6 +54,13 @@ public class ExhibitionBookmarkQueryIntegrationTest extends BaseIntegrationTest 
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionBookmarkCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -149,20 +145,6 @@ public class ExhibitionBookmarkQueryIntegrationTest extends BaseIntegrationTest 
 
             // then
             resultActions.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("북마크 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionBookmarkQueryPort).searchBookmarkedExhibitionByDeletedAtIsNull(any(), any(), any());
-
-            // when
-            ResultActions resultActions = requestSearchBookmarkedExhibitionAuthenticated(null, 0, 10);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -11,8 +10,8 @@ import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.common.api.constant.MultipartKey;
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCreateRequest;
-import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCreateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionUpdateRequest;
+import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCreateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionUpdateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionWorkCreateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionWorkUpdateRequestFixture;
@@ -22,41 +21,32 @@ import com.benchpress200.photique.exhibition.application.command.port.out.Exhibi
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.entity.ExhibitionWork;
-import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
-import com.benchpress200.photique.image.infrastructure.exception.ImageUploadException;
-import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.support.fixture.MultipartFileFixture;
 import com.benchpress200.photique.support.fixture.MultipartJsonFixture;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
-import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
 @DisplayName("전시회 커맨드 API 통합 테스트")
 public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
-
-    @Autowired
-    private UserQueryPort userQueryPort;
 
     @Autowired
     private UserCommandPort userCommandPort;
@@ -67,31 +57,20 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
-    private ImageUploaderPort imageUploaderPort;
-
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionWorkCommandPort exhibitionWorkCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionTagCommandPort exhibitionTagCommandPort;
-
-    @MockitoSpyBean
-    private OutboxEventPort outboxEventPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionTagCommandPort.deleteAll();
-        exhibitionWorkCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -100,6 +79,14 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionTagCommandPort.deleteAll();
+        exhibitionWorkCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -260,24 +247,6 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
         }
 
         @Test
-        @DisplayName("이미지 업로드에 실패하면 전시회를 저장하지 않고 500을 반환한다")
-        public void whenImageUploadFails() throws Exception {
-            // given
-            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-            List<MockMultipartFile> images = List.of(createValidImage());
-
-            Mockito.doThrow(new ImageUploadException("이미지 업로드 실패"))
-                    .when(imageUploaderPort).upload(any(), any());
-
-            // when
-            ResultActions resultActions = requestOpenExhibitionAuthenticated(request, images);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
-        }
-
-        @Test
         @DisplayName("존재하지 않는 유저로 요청하면 전시회를 저장하지 않고 404를 반환한다")
         public void whenUserNotFound() throws Exception {
             // given
@@ -295,78 +264,6 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isNotFound());
-            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
-        }
-
-        @Test
-        @DisplayName("전시회 저장에 실패하면 전시회를 저장하지 않고 500을 반환한다")
-        public void whenExhibitionSaveFails() throws Exception {
-            // given
-            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-            List<MockMultipartFile> images = List.of(createValidImage());
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestOpenExhibitionAuthenticated(request, images);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
-        }
-
-        @Test
-        @DisplayName("작품 저장에 실패하면 500을 반환한다")
-        public void whenExhibitionWorkSaveFails() throws Exception {
-            // given
-            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-            List<MockMultipartFile> images = List.of(createValidImage());
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionWorkCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestOpenExhibitionAuthenticated(request, images);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
-        }
-
-        @Test
-        @DisplayName("전시회 태그 저장에 실패하면 500을 반환한다")
-        public void whenExhibitionTagSaveFails() throws Exception {
-            // given
-            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-            List<MockMultipartFile> images = List.of(createValidImage());
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionTagCommandPort).saveAll(any());
-
-            // when
-            ResultActions resultActions = requestOpenExhibitionAuthenticated(request, images);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 500을 반환한다")
-        public void whenOutboxEventSaveFails() throws Exception {
-            // given
-            ExhibitionCreateRequest request = ExhibitionCreateRequestFixture.builder().build();
-            List<MockMultipartFile> images = List.of(createValidImage());
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestOpenExhibitionAuthenticated(request, images);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(exhibitionQueryPort.countByWriter(savedUser)).isEqualTo(0L);
         }
     }
@@ -662,24 +559,92 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
             // then
             resultActions.andExpect(status().isBadRequest());
         }
+    }
+
+    @Nested
+    @DisplayName("전시회 삭제")
+    class DeleteExhibitionTest {
+        private Exhibition savedExhibition;
+
+        @BeforeEach
+        void setUpExhibition() {
+            Exhibition exhibition = Exhibition.builder()
+                    .writer(savedUser)
+                    .title("삭제할 전시회 제목")
+                    .description("삭제할 전시회 설명")
+                    .cardColor("#FFFFFF")
+                    .viewCount(0L)
+                    .likeCount(0L)
+                    .build();
+            savedExhibition = exhibitionCommandPort.save(exhibition);
+        }
 
         @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 500을 반환한다")
-        public void whenOutboxEventSaveFails() throws Exception {
-            // given
-            ExhibitionUpdateRequest request = ExhibitionUpdateRequestFixture.builder().build();
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
+        @DisplayName("요청이 유효하면 전시회를 삭제하고 204를 반환한다")
+        public void whenRequestValid() throws Exception {
             // when
-            ResultActions resultActions = requestUpdateExhibitionDetailsAuthenticated(
-                    savedExhibition.getId(),
-                    request
+            ResultActions resultActions = requestDeleteExhibitionAuthenticated(savedExhibition.getId());
+            Optional<Exhibition> deletedExhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
+                    savedExhibition.getId()
             );
 
             // then
-            resultActions.andExpect(status().isInternalServerError());
+            resultActions.andExpect(status().isNoContent());
+            Assertions.assertThat(deletedExhibition).isNotPresent();
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 사용자면 전시회를 삭제하지 않고 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // when
+            ResultActions resultActions = requestDeleteExhibition(savedExhibition.getId());
+            Optional<Exhibition> exhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
+                    savedExhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+            Assertions.assertThat(exhibition).isPresent();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 전시회면 전시회를 삭제하지 않고 204를 반환한다")
+        public void whenExhibitionNotFound() throws Exception {
+            // when
+            ResultActions resultActions = requestDeleteExhibitionAuthenticated(
+                    savedExhibition.getId() + 999L
+            );
+
+            // then
+            resultActions.andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("전시회 소유자가 아니면 전시회를 삭제하지 않고 403을 반환한다")
+        public void whenNotOwned() throws Exception {
+            // given
+            User otherUser = UserFixture.builder()
+                    .email("other@example.com")
+                    .nickname("다른유저")
+                    .build();
+            User savedOtherUser = userCommandPort.save(otherUser);
+            AuthenticationTokens otherTokens = authenticationTokenManagerPort.issueTokens(
+                    savedOtherUser.getId(),
+                    savedOtherUser.getRole().name()
+            );
+
+            // when
+            ResultActions resultActions = requestDeleteExhibitionWithToken(
+                    savedExhibition.getId(),
+                    otherTokens.getAccessToken()
+            );
+            Optional<Exhibition> exhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
+                    savedExhibition.getId()
+            );
+
+            // then
+            resultActions.andExpect(status().isForbidden());
+            Assertions.assertThat(exhibition).isPresent();
         }
     }
 
@@ -863,111 +828,6 @@ public class ExhibitionCommandIntegrationTest extends BaseIntegrationTest {
                 .header("Authorization", "Bearer " + accessToken);
 
         return mockMvc.perform(httpBuilder);
-    }
-
-    @Nested
-    @DisplayName("전시회 삭제")
-    class DeleteExhibitionTest {
-        private Exhibition savedExhibition;
-
-        @BeforeEach
-        void setUpExhibition() {
-            Exhibition exhibition = Exhibition.builder()
-                    .writer(savedUser)
-                    .title("삭제할 전시회 제목")
-                    .description("삭제할 전시회 설명")
-                    .cardColor("#FFFFFF")
-                    .viewCount(0L)
-                    .likeCount(0L)
-                    .build();
-            savedExhibition = exhibitionCommandPort.save(exhibition);
-        }
-
-        @Test
-        @DisplayName("요청이 유효하면 전시회를 삭제하고 204를 반환한다")
-        public void whenRequestValid() throws Exception {
-            // when
-            ResultActions resultActions = requestDeleteExhibitionAuthenticated(savedExhibition.getId());
-            Optional<Exhibition> deletedExhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isNoContent());
-            Assertions.assertThat(deletedExhibition).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("인증되지 않은 사용자면 전시회를 삭제하지 않고 401을 반환한다")
-        public void whenNotAuthenticated() throws Exception {
-            // when
-            ResultActions resultActions = requestDeleteExhibition(savedExhibition.getId());
-            Optional<Exhibition> exhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isUnauthorized());
-            Assertions.assertThat(exhibition).isPresent();
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 전시회면 전시회를 삭제하지 않고 204를 반환한다")
-        public void whenExhibitionNotFound() throws Exception {
-            // when
-            ResultActions resultActions = requestDeleteExhibitionAuthenticated(
-                    savedExhibition.getId() + 999L
-            );
-
-            // then
-            resultActions.andExpect(status().isNoContent());
-        }
-
-        @Test
-        @DisplayName("전시회 소유자가 아니면 전시회를 삭제하지 않고 403을 반환한다")
-        public void whenNotOwned() throws Exception {
-            // given
-            User otherUser = UserFixture.builder()
-                    .email("other@example.com")
-                    .nickname("다른유저")
-                    .build();
-            User savedOtherUser = userCommandPort.save(otherUser);
-            AuthenticationTokens otherTokens = authenticationTokenManagerPort.issueTokens(
-                    savedOtherUser.getId(),
-                    savedOtherUser.getRole().name()
-            );
-
-            // when
-            ResultActions resultActions = requestDeleteExhibitionWithToken(
-                    savedExhibition.getId(),
-                    otherTokens.getAccessToken()
-            );
-            Optional<Exhibition> exhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isForbidden());
-            Assertions.assertThat(exhibition).isPresent();
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 전시회를 삭제하지 않고 500을 반환한다")
-        public void whenOutboxEventSaveFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestDeleteExhibitionAuthenticated(savedExhibition.getId());
-            Optional<Exhibition> exhibition = exhibitionQueryPort.findByIdAndDeletedAtIsNull(
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exhibition).isPresent();
-        }
     }
 
     private ResultActions requestDeleteExhibition(Long exhibitionId) throws Exception {

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommentCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommentCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -13,30 +12,27 @@ import com.benchpress200.photique.exhibition.api.command.request.ExhibitionComme
 import com.benchpress200.photique.exhibition.api.command.request.ExhibitionCommentUpdateRequest;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCommentCreateRequestFixture;
 import com.benchpress200.photique.exhibition.api.command.support.fixture.ExhibitionCommentUpdateRequestFixture;
-import com.benchpress200.photique.exhibition.domain.entity.ExhibitionComment;
-import com.benchpress200.photique.exhibition.domain.support.ExhibitionCommentFixture;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommentCommandPort;
 import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionCommentQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionComment;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionCommentFixture;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
-import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("전시회 감상평 커맨드 API 통합 테스트")
@@ -51,24 +47,17 @@ public class ExhibitionCommentCommandIntegrationTest extends BaseIntegrationTest
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommentCommandPort exhibitionCommentCommandPort;
-
-    @MockitoSpyBean
-    private OutboxEventPort outboxEventPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionCommentCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -77,6 +66,13 @@ public class ExhibitionCommentCommandIntegrationTest extends BaseIntegrationTest
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionCommentCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -190,56 +186,6 @@ public class ExhibitionCommentCommandIntegrationTest extends BaseIntegrationTest
 
             // then
             resultActions.andExpect(status().isBadRequest());
-            Assertions.assertThat(commentCount).isZero();
-        }
-
-        @Test
-        @DisplayName("감상평 저장에 실패하면 감상평을 저장하지 않고 500을 반환한다")
-        public void whenCommentSaveFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder().build();
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionCommentCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestCreateExhibitionCommentAuthenticated(exhibition.getId(), request);
-            long commentCount = exhibitionCommentQueryPort.findByExhibitionId(
-                    exhibition.getId(),
-                    Pageable.unpaged()
-            ).getTotalElements();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(commentCount).isZero();
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 감상평을 저장하지 않고 500을 반환한다")
-        public void whenOutboxSaveFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            ExhibitionCommentCreateRequest request = ExhibitionCommentCreateRequestFixture.builder().build();
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestCreateExhibitionCommentAuthenticated(exhibition.getId(), request);
-            long commentCount = exhibitionCommentQueryPort.findByExhibitionId(
-                    exhibition.getId(),
-                    Pageable.unpaged()
-            ).getTotalElements();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(commentCount).isZero();
         }
     }
@@ -419,29 +365,6 @@ public class ExhibitionCommentCommandIntegrationTest extends BaseIntegrationTest
         }
     }
 
-    private ResultActions requestCreateExhibitionComment(
-            Long exhibitionId,
-            ExhibitionCommentCreateRequest request
-    ) throws Exception {
-        return mockMvc.perform(
-                post(ApiPath.EXHIBITION_COMMENT, exhibitionId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-        );
-    }
-
-    private ResultActions requestCreateExhibitionCommentAuthenticated(
-            Long exhibitionId,
-            ExhibitionCommentCreateRequest request
-    ) throws Exception {
-        return mockMvc.perform(
-                post(ApiPath.EXHIBITION_COMMENT, exhibitionId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-        );
-    }
-
     @Nested
     @DisplayName("전시회 감상평 삭제")
     class DeleteExhibitionCommentTest {
@@ -545,6 +468,29 @@ public class ExhibitionCommentCommandIntegrationTest extends BaseIntegrationTest
             resultActions.andExpect(status().isForbidden());
             Assertions.assertThat(exists).isTrue();
         }
+    }
+
+    private ResultActions requestCreateExhibitionComment(
+            Long exhibitionId,
+            ExhibitionCommentCreateRequest request
+    ) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.EXHIBITION_COMMENT, exhibitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    private ResultActions requestCreateExhibitionCommentAuthenticated(
+            Long exhibitionId,
+            ExhibitionCommentCreateRequest request
+    ) throws Exception {
+        return mockMvc.perform(
+                post(ApiPath.EXHIBITION_COMMENT, exhibitionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
     }
 
     private ResultActions requestUpdateExhibitionComment(

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommentQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionCommentQueryIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,7 +9,6 @@ import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommentCommandPort;
-import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionCommentQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.entity.ExhibitionComment;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionCommentFixture;
@@ -19,15 +17,13 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -40,24 +36,17 @@ public class ExhibitionCommentQueryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommentCommandPort exhibitionCommentCommandPort;
-
-    @MockitoSpyBean
-    private ExhibitionCommentQueryPort exhibitionCommentQueryPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionCommentCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -66,6 +55,13 @@ public class ExhibitionCommentQueryIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionCommentCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -159,25 +155,6 @@ public class ExhibitionCommentQueryIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("감상평 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Exhibition savedExhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionCommentQueryPort).findByExhibitionId(any(), any());
-
-            // when
-            ResultActions resultActions = requestGetExhibitionCommentsAuthenticated(savedExhibition.getId(), 0, 10);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,21 +14,18 @@ import com.benchpress200.photique.exhibition.application.query.port.out.persiste
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.entity.ExhibitionLike;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
-import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("전시회 좋아요 커맨드 API 통합 테스트")
@@ -47,24 +43,17 @@ public class ExhibitionLikeCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionLikeCommandPort exhibitionLikeCommandPort;
-
-    @MockitoSpyBean
-    private OutboxEventPort outboxEventPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionLikeCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -73,6 +62,13 @@ public class ExhibitionLikeCommandIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionLikeCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -157,78 +153,6 @@ public class ExhibitionLikeCommandIntegrationTest extends BaseIntegrationTest {
             // then
             resultActions.andExpect(status().isConflict());
         }
-
-        @Test
-        @DisplayName("좋아요 저장에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
-        public void whenLikeSaveFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionLikeCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
-            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    exhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exists).isFalse();
-        }
-
-        @Test
-        @DisplayName("좋아요 수 증가에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
-        public void whenIncrementLikeCountFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionCommandPort).incrementLikeCount(any());
-
-            // when
-            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
-            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    exhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exists).isFalse();
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 좋아요를 저장하지 않고 500을 반환한다")
-        public void whenOutboxSaveFails() throws Exception {
-            // given
-            Exhibition exhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestAddExhibitionLikeAuthenticated(exhibition.getId());
-            boolean exists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    exhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(exists).isFalse();
-        }
     }
 
     @Nested
@@ -307,81 +231,6 @@ public class ExhibitionLikeCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isNoContent());
-        }
-
-        @Test
-        @DisplayName("좋아요 삭제에 실패하면 롤백하고 500을 반환한다")
-        public void whenLikeDeleteFails() throws Exception {
-            // given
-            Exhibition savedExhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            requestAddExhibitionLikeAuthenticated(savedExhibition.getId());
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionLikeCommandPort).delete(any());
-
-            // when
-            ResultActions resultActions = requestCancelExhibitionLikeAuthenticated(savedExhibition.getId());
-            boolean likeExists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(likeExists).isTrue();
-        }
-
-        @Test
-        @DisplayName("좋아요 수 감소에 실패하면 롤백하고 500을 반환한다")
-        public void whenDecrementLikeCountFails() throws Exception {
-            // given
-            Exhibition savedExhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            requestAddExhibitionLikeAuthenticated(savedExhibition.getId());
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionCommandPort).decrementLikeCount(any());
-
-            // when
-            ResultActions resultActions = requestCancelExhibitionLikeAuthenticated(savedExhibition.getId());
-            boolean likeExists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(likeExists).isTrue();
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 롤백하고 500을 반환한다")
-        public void whenOutboxSaveFails() throws Exception {
-            // given
-            Exhibition savedExhibition = exhibitionCommandPort.save(
-                    ExhibitionFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            requestAddExhibitionLikeAuthenticated(savedExhibition.getId());
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestCancelExhibitionLikeAuthenticated(savedExhibition.getId());
-            boolean likeExists = exhibitionLikeQueryPort.existsByUserIdAndExhibitionId(
-                    savedUser.getId(),
-                    savedExhibition.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(likeExists).isTrue();
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionLikeQueryIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,7 +9,6 @@ import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionLikeCommandPort;
-import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionLikeQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.entity.ExhibitionLike;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
@@ -18,15 +16,13 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -39,24 +35,17 @@ public class ExhibitionLikeQueryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionLikeCommandPort exhibitionLikeCommandPort;
-
-    @MockitoSpyBean
-    private ExhibitionLikeQueryPort exhibitionLikeQueryPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        exhibitionLikeCommandPort.deleteAll();
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -65,6 +54,13 @@ public class ExhibitionLikeQueryIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionLikeCommandPort.deleteAll();
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -149,20 +145,6 @@ public class ExhibitionLikeQueryIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("좋아요 전시회 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionLikeQueryPort).searchLikedExhibitionByDeletedAtIsNull(any(), any(), any());
-
-            // when
-            ResultActions resultActions = requestSearchLikedExhibitionAuthenticated(null, 0, 10);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
@@ -16,6 +16,7 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,9 +48,6 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        exhibitionCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -58,6 +56,12 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
@@ -1,0 +1,157 @@
+package com.benchpress200.photique.integration.exhibition;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
+import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
+import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
+import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
+import com.benchpress200.photique.support.base.BaseIntegrationTest;
+import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("전시회 쿼리 API 통합 테스트")
+public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UserCommandPort userCommandPort;
+
+    @Autowired
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    @MockitoSpyBean
+    private ExhibitionCommandPort exhibitionCommandPort;
+
+    @MockitoSpyBean
+    private ExhibitionQueryPort exhibitionQueryPort;
+
+    private User savedUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        exhibitionCommandPort.deleteAll();
+        userCommandPort.deleteAll();
+
+        User user = UserFixture.builder().build();
+        savedUser = userCommandPort.save(user);
+
+        AuthenticationTokens tokens = authenticationTokenManagerPort.issueTokens(
+                savedUser.getId(),
+                savedUser.getRole().name()
+        );
+        accessToken = tokens.getAccessToken();
+    }
+
+    @Nested
+    @DisplayName("전시회 상세 조회")
+    class GetExhibitionDetailsTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 전시회 상세 정보를 반환하고 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestGetExhibitionDetailsAuthenticated(savedExhibition.getId());
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").value(savedExhibition.getId()))
+                    .andExpect(jsonPath("$.data.writer.id").value(savedUser.getId()))
+                    .andExpect(jsonPath("$.data.writer.nickname").value(savedUser.getNickname()))
+                    .andExpect(jsonPath("$.data.writer.profileImage").value(savedUser.getProfileImage()))
+                    .andExpect(jsonPath("$.data.writer.introduction").value(savedUser.getIntroduction()))
+                    .andExpect(jsonPath("$.data.title").value(savedExhibition.getTitle()))
+                    .andExpect(jsonPath("$.data.description").value(savedExhibition.getDescription()))
+                    .andExpect(jsonPath("$.data.tags.length()").value(0))
+                    .andExpect(jsonPath("$.data.works.length()").value(0))
+                    .andExpect(jsonPath("$.data.viewCount").value(savedExhibition.getViewCount()))
+                    .andExpect(jsonPath("$.data.likeCount").value(savedExhibition.getLikeCount()))
+                    .andExpect(jsonPath("$.data.createdAt").exists())
+                    .andExpect(jsonPath("$.data.isFollowing").value(false))
+                    .andExpect(jsonPath("$.data.isLiked").value(false))
+                    .andExpect(jsonPath("$.data.isBookmarked").value(false));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestGetExhibitionDetails(savedExhibition.getId());
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 전시회이면 404를 반환한다")
+        public void whenExhibitionNotFound() throws Exception {
+            // given
+            Long nonExistentId = 9999L;
+
+            // when
+            ResultActions resultActions = requestGetExhibitionDetailsAuthenticated(nonExistentId);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("전시회 조회 중 DB 예외가 발생하면 500을 반환한다")
+        public void whenQueryFails() throws Exception {
+            // given
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            ResultActions resultActions = requestGetExhibitionDetailsAuthenticated(1L);
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+        }
+    }
+
+    private ResultActions requestGetExhibitionDetails(Long exhibitionId) throws Exception {
+        return mockMvc.perform(
+                get(ApiPath.EXHIBITION_DATA, exhibitionId)
+        );
+    }
+
+    private ResultActions requestGetExhibitionDetailsAuthenticated(Long exhibitionId) throws Exception {
+        return mockMvc.perform(
+                get(ApiPath.EXHIBITION_DATA, exhibitionId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
+    }
+}

--- a/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/notification/NotificationCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.notification;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,25 +18,23 @@ import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("알림 커맨드 API 통합 테스트")
 public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
 
-    @MockitoSpyBean
+    @Autowired
     private NotificationCommandPort notificationCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private NotificationQueryPort notificationQueryPort;
 
     @Autowired
@@ -51,9 +48,6 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        notificationCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -62,6 +56,12 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        notificationCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -128,35 +128,6 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
             // then
             resultActions.andExpect(status().isNotFound());
         }
-
-        @Test
-        @DisplayName("알림 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Notification savedNotification = notificationCommandPort.save(
-                    NotificationFixture.builder()
-                            .receiver(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
-
-            // when
-            ResultActions resultActions = requestMarkAsReadAuthenticated(savedNotification.getId());
-
-            // 스파이 복원 후 DB 상태 검증
-            Mockito.doCallRealMethod().when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
-            Optional<Notification> notification = notificationQueryPort.findByIdAndDeletedAtIsNull(
-                    savedNotification.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(notification)
-                    .isPresent()
-                    .get()
-                    .satisfies(n -> Assertions.assertThat(n.isRead()).isFalse());
-        }
     }
 
     @Nested
@@ -217,32 +188,6 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
             // then
             resultActions.andExpect(status().isNoContent());
         }
-
-        @Test
-        @DisplayName("알림 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Notification savedNotification = notificationCommandPort.save(
-                    NotificationFixture.builder()
-                            .receiver(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
-
-            // when
-            ResultActions resultActions = requestDeleteNotificationAuthenticated(savedNotification.getId());
-
-            // 스파이 복원 후 DB 상태 검증
-            Mockito.doCallRealMethod().when(notificationQueryPort).findByIdAndDeletedAtIsNull(any());
-            Optional<Notification> notification = notificationQueryPort.findByIdAndDeletedAtIsNull(
-                    savedNotification.getId()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(notification).isPresent();
-        }
     }
 
     @Nested
@@ -302,41 +247,6 @@ public class NotificationCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isUnauthorized());
-            Assertions.assertThat(notifications)
-                    .hasSize(2)
-                    .allSatisfy(n -> Assertions.assertThat(n.isRead()).isFalse());
-        }
-
-        @Test
-        @DisplayName("전체 읽음 처리 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenMarkAllAsReadFails() throws Exception {
-            // given
-            notificationCommandPort.save(
-                    NotificationFixture.builder()
-                            .receiver(savedUser)
-                            .build()
-            );
-            notificationCommandPort.save(
-                    NotificationFixture.builder()
-                            .receiver(savedUser)
-                            .build()
-            );
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(notificationCommandPort).markAllAsReadByReceiverIdAndDeletedAtIsNull(any());
-
-            // when
-            ResultActions resultActions = requestMarkAllAsReadAuthenticated();
-
-            // 스파이 복원 후 DB 상태 검증
-            Mockito.doCallRealMethod()
-                    .when(notificationCommandPort).markAllAsReadByReceiverIdAndDeletedAtIsNull(any());
-            List<Notification> notifications = notificationQueryPort.findByReceiverIdAndDeletedAtIsNull(
-                    savedUser.getId(),
-                    Pageable.unpaged()
-            ).getContent();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(notifications)
                     .hasSize(2)
                     .allSatisfy(n -> Assertions.assertThat(n.isRead()).isFalse());

--- a/src/test/java/com/benchpress200/photique/integration/notification/NotificationQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/notification/NotificationQueryIntegrationTest.java
@@ -1,0 +1,172 @@
+package com.benchpress200.photique.integration.notification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
+import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
+import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.notification.application.command.port.out.persistence.NotificationCommandPort;
+import com.benchpress200.photique.notification.application.query.port.out.persistence.NotificationQueryPort;
+import com.benchpress200.photique.notification.domain.entity.Notification;
+import com.benchpress200.photique.notification.domain.support.NotificationFixture;
+import com.benchpress200.photique.support.base.BaseIntegrationTest;
+import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
+import com.benchpress200.photique.user.domain.entity.User;
+import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+@DisplayName("알림 쿼리 API 통합 테스트")
+public class NotificationQueryIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UserCommandPort userCommandPort;
+
+    @Autowired
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    @MockitoSpyBean
+    private NotificationCommandPort notificationCommandPort;
+
+    @MockitoSpyBean
+    private NotificationQueryPort notificationQueryPort;
+
+    private User savedUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        notificationCommandPort.deleteAll();
+        userCommandPort.deleteAll();
+
+        User user = UserFixture.builder().build();
+        savedUser = userCommandPort.save(user);
+
+        AuthenticationTokens tokens = authenticationTokenManagerPort.issueTokens(
+                savedUser.getId(),
+                savedUser.getRole().name()
+        );
+        accessToken = tokens.getAccessToken();
+    }
+
+    @Nested
+    @DisplayName("알림 페이지 조회")
+    class GetNotificationPageTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 알림 페이지를 반환하고 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Notification savedNotification = notificationCommandPort.save(
+                    NotificationFixture.builder()
+                            .receiver(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestGetNotificationPageAuthenticated(0, 30);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(30))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.isLast").value(true))
+                    .andExpect(jsonPath("$.data.hasNext").value(false))
+                    .andExpect(jsonPath("$.data.hasPrevious").value(false))
+                    .andExpect(jsonPath("$.data.notifications.length()").value(1))
+                    .andExpect(jsonPath("$.data.notifications[0].id").value(savedNotification.getId()))
+                    .andExpect(jsonPath("$.data.notifications[0].type").value(savedNotification.getType().getValue()))
+                    .andExpect(jsonPath("$.data.notifications[0].isRead").value(false))
+                    .andExpect(jsonPath("$.data.unread").value(true));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // when
+            ResultActions resultActions = requestGetNotificationPage(0, 30);
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageNegative() throws Exception {
+            // when
+            ResultActions resultActions = requestGetNotificationPageAuthenticated(-1, 30);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 사이즈가 유효 범위를 벗어나면 400을 반환한다")
+        public void whenSizeOutOfRange() throws Exception {
+            // when
+            ResultActions resultActions = requestGetNotificationPageAuthenticated(0, 0);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("알림 조회 중 DB 예외가 발생하면 500을 반환한다")
+        public void whenQueryFails() throws Exception {
+            // given
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(notificationQueryPort).findByReceiverIdAndDeletedAtIsNull(any(), any());
+
+            // when
+            ResultActions resultActions = requestGetNotificationPageAuthenticated(0, 30);
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+        }
+    }
+
+    private ResultActions requestGetNotificationPage(
+            Integer page,
+            Integer size
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.NOTIFICATION_ROOT);
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+
+    private ResultActions requestGetNotificationPageAuthenticated(
+            Integer page,
+            Integer size
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.NOTIFICATION_ROOT)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+}

--- a/src/test/java/com/benchpress200/photique/integration/notification/NotificationQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/notification/NotificationQueryIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.notification;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -16,15 +15,13 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -37,10 +34,10 @@ public class NotificationQueryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private NotificationCommandPort notificationCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private NotificationQueryPort notificationQueryPort;
 
     private User savedUser;
@@ -48,9 +45,6 @@ public class NotificationQueryIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        notificationCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -59,6 +53,12 @@ public class NotificationQueryIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        notificationCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -124,20 +124,6 @@ public class NotificationQueryIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("알림 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(notificationQueryPort).findByReceiverIdAndDeletedAtIsNull(any(), any());
-
-            // when
-            ResultActions resultActions = requestGetNotificationPageAuthenticated(0, 30);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
@@ -3,6 +3,7 @@ package com.benchpress200.photique.integration.singlework;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
@@ -11,25 +12,32 @@ import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
 import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
 import com.benchpress200.photique.singlework.api.command.request.SingleWorkCreateRequest;
+import com.benchpress200.photique.singlework.api.command.request.SingleWorkUpdateRequest;
 import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCreateRequestFixture;
+import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkUpdateRequestFixture;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkCommandPort;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkTagCommandPort;
 import com.benchpress200.photique.singlework.application.query.port.out.persistence.SingleWorkQueryPort;
+import com.benchpress200.photique.singlework.domain.entity.SingleWork;
+import com.benchpress200.photique.singlework.domain.support.SingleWorkFixture;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.support.fixture.MultipartFileFixture;
 import com.benchpress200.photique.support.fixture.MultipartJsonFixture;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
@@ -43,7 +51,7 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private SingleWorkTagCommandPort singleWorkTagCommandPort;
 
-    @Autowired
+    @MockitoSpyBean
     private SingleWorkQueryPort singleWorkQueryPort;
 
     @Autowired
@@ -252,6 +260,174 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
             resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(workCount).isZero();
         }
+    }
+
+    @Nested
+    @DisplayName("단일작품 수정")
+    class UpdateSingleWorkDetailsTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 단일작품을 수정하고 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            SingleWork savedSingleWork = singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(savedSingleWork.getId(), request);
+            Optional<SingleWork> singleWork = singleWorkQueryPort.findByIdAndDeletedAtIsNull(savedSingleWork.getId());
+
+            // then
+            resultActions.andExpect(status().isNoContent());
+            Assertions.assertThat(singleWork)
+                    .isPresent()
+                    .get()
+                    .satisfies(w -> Assertions.assertThat(w.getTitle()).isEqualTo(request.getTitle()));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            SingleWork savedSingleWork = singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWork(savedSingleWork.getId(), request);
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 단일작품이면 404를 반환한다")
+        public void whenSingleWorkNotFound() throws Exception {
+            // given
+            Long nonExistentId = 9999L;
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(nonExistentId, request);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("본인 소유가 아닌 단일작품이면 403을 반환한다")
+        public void whenNotOwned() throws Exception {
+            // given
+            User otherUser = userCommandPort.save(
+                    UserFixture.builder()
+                            .email("other@example.com")
+                            .nickname("다른유저")
+                            .build()
+            );
+            SingleWork savedSingleWork = singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(otherUser)
+                            .build()
+            );
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(savedSingleWork.getId(), request);
+
+            // then
+            resultActions.andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("제목이 최대 길이를 초과하면 400을 반환한다")
+        public void whenTitleTooLong() throws Exception {
+            // given
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder()
+                    .title("가".repeat(31))
+                    .updateTitle(true)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(1L, request);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("단일작품 조회 중 DB 예외가 발생하면 500을 반환한다")
+        public void whenQueryFails() throws Exception {
+            // given
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(
+                    1L,
+                    SingleWorkUpdateRequestFixture.builder().build()
+            );
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+        }
+
+        @Test
+        @DisplayName("아웃박스 이벤트 저장에 실패하면 단일작품을 수정하지 않고 500을 반환한다")
+        public void whenOutboxSaveFails() throws Exception {
+            // given
+            SingleWork savedSingleWork = singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
+            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
+                    .when(outboxEventPort).save(any());
+
+            // when
+            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(savedSingleWork.getId(), request);
+
+            // 스파이 복원 후 DB 상태 검증
+            Mockito.doCallRealMethod().when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
+            Optional<SingleWork> singleWork = singleWorkQueryPort.findByIdAndDeletedAtIsNull(savedSingleWork.getId());
+
+            // then
+            resultActions.andExpect(status().isInternalServerError());
+            Assertions.assertThat(singleWork)
+                    .isPresent()
+                    .get()
+                    .satisfies(w -> Assertions.assertThat(w.getTitle()).isEqualTo(savedSingleWork.getTitle()));
+        }
+    }
+
+    private ResultActions requestUpdateSingleWork(
+            Long singleWorkId,
+            SingleWorkUpdateRequest request
+    ) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.SINGLEWORK_DATA, singleWorkId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+    }
+
+    private ResultActions requestUpdateSingleWorkAuthenticated(
+            Long singleWorkId,
+            SingleWorkUpdateRequest request
+    ) throws Exception {
+        return mockMvc.perform(
+                patch(ApiPath.SINGLEWORK_DATA, singleWorkId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
     }
 
     private ResultActions requestPostSingleWork(SingleWorkCreateRequest request) throws Exception {

--- a/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
@@ -46,7 +45,7 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private SingleWorkTagCommandPort singleWorkTagCommandPort;
 
-    @MockitoSpyBean
+    @Autowired
     private SingleWorkQueryPort singleWorkQueryPort;
 
     @Autowired
@@ -288,51 +287,6 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isBadRequest());
-        }
-
-        @Test
-        @DisplayName("단일작품 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-
-            // when
-            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(
-                    1L,
-                    SingleWorkUpdateRequestFixture.builder().build()
-            );
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 단일작품을 수정하지 않고 500을 반환한다")
-        public void whenOutboxSaveFails() throws Exception {
-            // given
-            SingleWork savedSingleWork = singleWorkCommandPort.save(
-                    SingleWorkFixture.builder()
-                            .writer(savedUser)
-                            .build()
-            );
-            SingleWorkUpdateRequest request = SingleWorkUpdateRequestFixture.builder().build();
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestUpdateSingleWorkAuthenticated(savedSingleWork.getId(), request);
-
-            // 스파이 복원 후 DB 상태 검증
-            Mockito.doCallRealMethod().when(singleWorkQueryPort).findByIdAndDeletedAtIsNull(any());
-            Optional<SingleWork> singleWork = singleWorkQueryPort.findByIdAndDeletedAtIsNull(savedSingleWork.getId());
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(singleWork)
-                    .isPresent()
-                    .get()
-                    .satisfies(w -> Assertions.assertThat(w.getTitle()).isEqualTo(savedSingleWork.getTitle()));
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkCommandIntegrationTest.java
@@ -1,15 +1,11 @@
 package com.benchpress200.photique.integration.singlework;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
 import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
-import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
-import com.benchpress200.photique.outbox.application.port.out.persistence.OutboxEventPort;
 import com.benchpress200.photique.singlework.api.command.request.SingleWorkCreateRequest;
 import com.benchpress200.photique.singlework.api.command.support.fixture.SingleWorkCreateRequestFixture;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkCommandPort;
@@ -22,16 +18,15 @@ import com.benchpress200.photique.user.application.command.port.out.persistence.
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("단일작품 커맨드 API 통합 테스트")
@@ -49,24 +44,14 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
-    private ImageUploaderPort imageUploaderPort;
-
-    @MockitoSpyBean
+    @Autowired
     private SingleWorkCommandPort singleWorkCommandPort;
-
-    @MockitoSpyBean
-    private OutboxEventPort outboxEventPort;
 
     private User savedUser;
     private String accessToken;
 
     @BeforeEach
     void setUp() {
-        singleWorkTagCommandPort.deleteAll();
-        singleWorkCommandPort.deleteAll();
-        userCommandPort.deleteAll();
-
         User user = UserFixture.builder().build();
         savedUser = userCommandPort.save(user);
 
@@ -75,6 +60,13 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
                 savedUser.getRole().name()
         );
         accessToken = tokens.getAccessToken();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        singleWorkTagCommandPort.deleteAll();
+        singleWorkCommandPort.deleteAll();
+        userCommandPort.deleteAll();
     }
 
     @Nested
@@ -187,69 +179,6 @@ public class SingleWorkCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isBadRequest());
-            Assertions.assertThat(workCount).isZero();
-        }
-
-        @Test
-        @DisplayName("이미지 업로드에 실패하면 단일작품을 저장하지 않고 500을 반환한다")
-        public void whenImageUploadFails() throws Exception {
-            // given
-            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build();
-            doThrow(new DataAccessResourceFailureException("S3 에러"))
-                    .when(imageUploaderPort).upload(any(), any());
-
-            // when
-            ResultActions resultActions = requestPostSingleWorkAuthenticated(request);
-            long workCount = singleWorkQueryPort.searchMySingleWorkByDeletedAtIsNull(
-                    savedUser.getId(),
-                    "",
-                    Pageable.unpaged()
-            ).getTotalElements();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(workCount).isZero();
-        }
-
-        @Test
-        @DisplayName("단일작품 저장에 실패하면 단일작품을 저장하지 않고 500을 반환한다")
-        public void whenSingleWorkSaveFails() throws Exception {
-            // given
-            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build();
-            doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(singleWorkCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestPostSingleWorkAuthenticated(request);
-            long workCount = singleWorkQueryPort.searchMySingleWorkByDeletedAtIsNull(
-                    savedUser.getId(),
-                    "",
-                    Pageable.unpaged()
-            ).getTotalElements();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(workCount).isZero();
-        }
-
-        @Test
-        @DisplayName("아웃박스 이벤트 저장에 실패하면 단일작품을 저장하지 않고 500을 반환한다")
-        public void whenOutboxSaveFails() throws Exception {
-            // given
-            SingleWorkCreateRequest request = SingleWorkCreateRequestFixture.builder().build();
-            doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(outboxEventPort).save(any());
-
-            // when
-            ResultActions resultActions = requestPostSingleWorkAuthenticated(request);
-            long workCount = singleWorkQueryPort.searchMySingleWorkByDeletedAtIsNull(
-                    savedUser.getId(),
-                    "",
-                    Pageable.unpaged()
-            ).getTotalElements();
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(workCount).isZero();
         }
     }

--- a/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.user;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -8,8 +7,6 @@ import com.benchpress200.photique.auth.application.command.port.out.persistence.
 import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.common.api.constant.MultipartKey;
-import com.benchpress200.photique.image.domain.port.storage.ImageUploaderPort;
-import com.benchpress200.photique.image.infrastructure.exception.ImageUploadException;
 import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.support.fixture.MultipartFileFixture;
@@ -22,18 +19,15 @@ import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
@@ -46,14 +40,11 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthMailCodeCommandPort authMailCodeCommandPort;
 
-    @MockitoSpyBean
-    private ImageUploaderPort imageUploaderPort;
-
-    @MockitoSpyBean
+    @Autowired
     private UserCommandPort userCommandPort;
 
-    @BeforeEach
-    void cleanAuthMailCode() {
+    @AfterEach
+    void cleanUp() {
         authMailCodeCommandPort.deleteAll();
         userCommandPort.deleteAll();
     }
@@ -245,75 +236,6 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isUnauthorized());
-            Assertions.assertThat(user).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("프로필 이미지 업로드에 실패한다면 가입을 진행하지 않고 500을 반환한다")
-        public void whenProfileImageUploadFailed() throws Exception {
-            // given
-            ResisterRequestFixture request = ResisterRequestFixture.builder().build();
-            MockMultipartFile userPart = MultipartJsonFixture.builder()
-                    .key(MultipartKey.USER)
-                    .object(request)
-                    .objectMapper(objectMapper)
-                    .build();
-
-            MockMultipartFile profileImage = MultipartFileFixture.builder()
-                    .key(MultipartKey.PROFILE_IMAGE)
-                    .fileName("profile.jpg")
-                    .contentType(MediaType.IMAGE_JPEG_VALUE)
-                    .content(new byte[1024 * 1024])
-                    .build();
-
-            String email = request.getEmail();
-
-            AuthMailCode authMailCode = AuthMailCodeFixture.builder()
-                    .email(email)
-                    .isVerified(true)
-                    .build();
-
-            authMailCodeCommandPort.save(authMailCode);
-
-            Mockito.doThrow(new ImageUploadException("이미지 업로드 실패")).when(imageUploaderPort).upload(any(), any());
-
-            // when
-            ResultActions resultActions = requestRegister(userPart, profileImage);
-            Optional<User> user = userQueryPort.findByEmailAndDeletedAtIsNull(email);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(user).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("유저 데이터 저장에 실패한다면 가입을 진행하지 않고 500을 반환한다")
-        public void whenUserSaveFailed() throws Exception {
-            // given
-            ResisterRequestFixture request = ResisterRequestFixture.builder().build();
-            MockMultipartFile userPart = MultipartJsonFixture.builder()
-                    .key(MultipartKey.USER)
-                    .object(request)
-                    .objectMapper(objectMapper)
-                    .build();
-
-            String email = request.getEmail();
-
-            AuthMailCode authMailCode = AuthMailCodeFixture.builder()
-                    .email(email)
-                    .isVerified(true)
-                    .build();
-
-            authMailCodeCommandPort.save(authMailCode);
-
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러")).when(userCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestRegister(userPart, null);
-            Optional<User> user = userQueryPort.findByEmailAndDeletedAtIsNull(email);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
             Assertions.assertThat(user).isNotPresent();
         }
 

--- a/src/test/java/com/benchpress200/photique/support/base/BaseTestContainerTest.java
+++ b/src/test/java/com/benchpress200/photique/support/base/BaseTestContainerTest.java
@@ -5,7 +5,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
@@ -15,19 +14,16 @@ public abstract class BaseTestContainerTest {
     private final static String IMAGE_ELASTICSEARCH = "docker.elastic.co/elasticsearch/elasticsearch:8.6.0";
 
 
-    @Container
     static MySQLContainer<?> mysql = new MySQLContainer<>(IMAGE_MYSQL)
             .withDatabaseName("photique_test")
             .withUsername("test")
             .withPassword("test")
             .withReuse(true);
 
-    @Container
     static GenericContainer<?> redis = new GenericContainer<>(IMAGE_REDIS)
             .withExposedPorts(6379)
             .withReuse(true);
 
-    @Container
     static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(IMAGE_ELASTICSEARCH)
             .withEnv("xpack.security.enabled", "false")
             .withEnv("xpack.security.http.ssl.enabled", "false")
@@ -54,4 +50,9 @@ public abstract class BaseTestContainerTest {
         registry.add("spring.elasticsearch.password", () -> "test");
     }
 
+    static {
+        mysql.start();
+        redis.start();
+        elasticsearch.start();
+    }
 }


### PR DESCRIPTION
# 목적
#265 요구에 따라서 NotificationQueryController.getNotificationPage API에 대한 통합 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청 유효
- 인증 토큰 없음
- 페이지 번호 음수
- 페이지 사이즈 유효 범위 초과
- DB 예외 발생

Closes #265