### PR TITLE
fix: 남은 스파이 빈 의존 제거 및 로컬, 테스트 프로파일 전용 메일센더 빈 추가

### DIFF
--- a/src/main/java/com/benchpress200/photique/auth/infrastructure/mail/adapter/LocalMailSenderAdapter.java
+++ b/src/main/java/com/benchpress200/photique/auth/infrastructure/mail/adapter/LocalMailSenderAdapter.java
@@ -1,0 +1,15 @@
+package com.benchpress200.photique.auth.infrastructure.mail.adapter;
+
+import com.benchpress200.photique.auth.application.command.port.out.mail.MailSenderPort;
+import com.benchpress200.photique.auth.domain.vo.MailContent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile({"local", "test"})
+@Component
+public class LocalMailSenderAdapter implements MailSenderPort {
+    @Override
+    public void sendMail(MailContent mailContent) {
+        // no-op
+    }
+}

--- a/src/main/java/com/benchpress200/photique/auth/infrastructure/mail/adapter/MailSenderAdapter.java
+++ b/src/main/java/com/benchpress200/photique/auth/infrastructure/mail/adapter/MailSenderAdapter.java
@@ -8,10 +8,12 @@ import com.benchpress200.photique.auth.infrastructure.exception.MailSendExceptio
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
+@Profile({"dev", "prod"}) // local이 아닐 때만 활성화
 @Component
 @RequiredArgsConstructor
 public class MailSenderAdapter implements MailSenderPort {

--- a/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/auth/AuthCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.auth;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,12 +8,9 @@ import com.benchpress200.photique.auth.api.command.request.AuthMailCodeValidateR
 import com.benchpress200.photique.auth.api.command.request.AuthMailRequest;
 import com.benchpress200.photique.auth.api.command.support.fixture.AuthMailCodeValidateRequestFixture;
 import com.benchpress200.photique.auth.api.command.support.fixture.AuthMailRequestFixture;
-import com.benchpress200.photique.auth.application.command.port.out.mail.MailSenderPort;
 import com.benchpress200.photique.auth.application.command.port.out.persistence.AuthMailCodeCommandPort;
 import com.benchpress200.photique.auth.application.query.port.out.persistence.AuthMailCodeQueryPort;
 import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
-import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
-import com.benchpress200.photique.auth.infrastructure.exception.MailSendException;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
@@ -24,17 +20,15 @@ import com.benchpress200.photique.user.domain.support.UserFixture;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("인증 커맨드 API 통합 테스트")
@@ -46,17 +40,18 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private UserCommandPort userCommandPort;
 
-    @MockitoSpyBean
-    private MailSenderPort mailSenderPort;
-
-    @MockitoSpyBean
+    @Autowired
     private AuthMailCodeCommandPort authMailCodeCommandPort;
 
     @BeforeEach
     void setUp() {
+
+    }
+
+    @AfterEach
+    void cleanUp() {
         userCommandPort.deleteAll();
         authMailCodeCommandPort.deleteAll();
-        Mockito.doNothing().when(mailSenderPort).sendMail(any());
     }
 
     @Nested
@@ -125,40 +120,6 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
             resultActions.andExpect(status().isConflict());
             Assertions.assertThat(authMailCode).isNotPresent();
         }
-
-        @Test
-        @DisplayName("메일 전송에 실패하면 인증 코드를 저장하지 않고 500을 반환한다")
-        public void whenMailSendFails() throws Exception {
-            // given
-            AuthMailRequest request = AuthMailRequestFixture.builder().build();
-            String email = request.getEmail();
-
-            Mockito.doThrow(new MailSendException("메일 전송 실패")).when(mailSenderPort).sendMail(any());
-
-            // when
-            ResultActions resultActions = requestSendJoinAuthMail(request);
-            Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(email);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(authMailCode).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("인증 코드 저장에 실패하면 500을 반환한다")
-        public void whenSaveFails() throws Exception {
-            // given
-            AuthMailRequest request = AuthMailRequestFixture.builder().build();
-
-            Mockito.doThrow(new DataAccessResourceFailureException("Redis 에러"))
-                    .when(authMailCodeCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestSendJoinAuthMail(request);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-        }
     }
 
     @Nested
@@ -226,53 +187,6 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
             // then
             resultActions.andExpect(status().isNotFound());
             Assertions.assertThat(authMailCode).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("메일 전송에 실패하면 인증 코드를 저장하지 않고 500을 반환한다")
-        public void whenMailSendFails() throws Exception {
-            // given
-            AuthMailRequest request = AuthMailRequestFixture.builder().build();
-            String email = request.getEmail();
-
-            User user = UserFixture.builder()
-                    .email(email)
-                    .build();
-
-            userCommandPort.save(user);
-
-            Mockito.doThrow(new MailSendException("메일 전송 실패")).when(mailSenderPort).sendMail(any());
-
-            // when
-            ResultActions resultActions = requestSendPasswordAuthMail(request);
-            Optional<AuthMailCode> authMailCode = authMailCodeQueryPort.findById(email);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
-            Assertions.assertThat(authMailCode).isNotPresent();
-        }
-
-        @Test
-        @DisplayName("인증 코드 저장에 실패하면 500을 반환한다")
-        public void whenSaveFails() throws Exception {
-            // given
-            AuthMailRequest request = AuthMailRequestFixture.builder().build();
-            String email = request.getEmail();
-
-            User user = UserFixture.builder()
-                    .email(email)
-                    .build();
-
-            userCommandPort.save(user);
-
-            Mockito.doThrow(new DataAccessResourceFailureException("Redis 에러"))
-                    .when(authMailCodeCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestSendPasswordAuthMail(request);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 
@@ -375,30 +289,6 @@ public class AuthCommandIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isGone());
-        }
-
-        @Test
-        @DisplayName("인증 코드 저장에 실패하면 500을 반환한다")
-        public void whenSaveFails() throws Exception {
-            // given
-            String code = "123456";
-            AuthMailCode authMailCode = AuthMailCodeFixture.builder()
-                    .code(code)
-                    .build();
-            authMailCodeCommandPort.save(authMailCode);
-
-            AuthMailCodeValidateRequest request = AuthMailCodeValidateRequestFixture.builder()
-                    .code(code)
-                    .build();
-
-            Mockito.doThrow(new DataAccessResourceFailureException("Redis 에러"))
-                    .when(authMailCodeCommandPort).save(any());
-
-            // when
-            ResultActions resultActions = requestValidateAuthMailCode(request);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.benchpress200.photique.integration.exhibition;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,7 +8,6 @@ import com.benchpress200.photique.auth.application.command.port.out.security.Aut
 import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
-import com.benchpress200.photique.exhibition.application.query.port.out.persistence.ExhibitionQueryPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
@@ -21,11 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 @DisplayName("전시회 쿼리 API 통합 테스트")
@@ -37,11 +32,8 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private AuthenticationTokenManagerPort authenticationTokenManagerPort;
 
-    @MockitoSpyBean
+    @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
-
-    @MockitoSpyBean
-    private ExhibitionQueryPort exhibitionQueryPort;
 
     private User savedUser;
     private String accessToken;
@@ -129,20 +121,6 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
 
             // then
             resultActions.andExpect(status().isNotFound());
-        }
-
-        @Test
-        @DisplayName("전시회 조회 중 DB 예외가 발생하면 500을 반환한다")
-        public void whenQueryFails() throws Exception {
-            // given
-            Mockito.doThrow(new DataAccessResourceFailureException("DB 에러"))
-                    .when(exhibitionQueryPort).findByIdAndDeletedAtIsNull(any());
-
-            // when
-            ResultActions resultActions = requestGetExhibitionDetailsAuthenticated(1L);
-
-            // then
-            resultActions.andExpect(status().isInternalServerError());
         }
     }
 


### PR DESCRIPTION
# 목적
통합 테스트 실행 시, 컨텍스트를 최대한 재사용 하도록 수정했습니다.

# 작업 내용
- 남아있던 MockitoSpyBean 및 관련 테스트 케이스 제거
- 로컬, 테스트 프로파일에서 동작할 MailSender 클래스 추가