### PR TITLE
test(exhibition): 전시회 검색 API 통합 테스트 코드 작성

### DIFF
--- a/src/main/java/com/benchpress200/photique/exhibition/application/query/result/ExhibitionSearchResult.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/query/result/ExhibitionSearchResult.java
@@ -39,6 +39,7 @@ public class ExhibitionSearchResult {
                 .page(exhibitionSearchPage.getNumber())
                 .size(exhibitionSearchPage.getSize())
                 .totalElements(exhibitionSearchPage.getTotalElements())
+                .totalPages(exhibitionSearchPage.getTotalPages())
                 .isFirst(exhibitionSearchPage.isFirst())
                 .isLast(exhibitionSearchPage.isLast())
                 .hasNext(exhibitionSearchPage.hasNext())

--- a/src/main/java/com/benchpress200/photique/exhibition/application/query/result/SearchedExhibition.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/application/query/result/SearchedExhibition.java
@@ -30,7 +30,7 @@ public class SearchedExhibition {
             boolean isBookmarked
     ) {
         Writer writer = Writer.of(
-                exhibitionSearch.getId(),
+                exhibitionSearch.getWriterId(),
                 exhibitionSearch.getWriterNickname(),
                 exhibitionSearch.getWriterProfileImage()
         );

--- a/src/main/java/com/benchpress200/photique/exhibition/domain/entity/ExhibitionSearch.java
+++ b/src/main/java/com/benchpress200/photique/exhibition/domain/entity/ExhibitionSearch.java
@@ -1,5 +1,6 @@
 package com.benchpress200.photique.exhibition.domain.entity;
 
+import com.benchpress200.photique.user.domain.entity.User;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -74,6 +75,38 @@ public class ExhibitionSearch {
     @Field(type = FieldType.Long)
     private Long lastProcessedEventId;
 
+
+    public static ExhibitionSearch of(
+            Long id,
+            User user,
+            String cardColor,
+            String title,
+            String description,
+            List<String> tags,
+            Long viewCount,
+            Long likeCount,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        Writer writer = Writer.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .build();
+
+        return ExhibitionSearch.builder()
+                .id(id)
+                .writer(writer)
+                .cardColor(cardColor)
+                .title(title)
+                .description(description)
+                .tags(tags)
+                .viewCount(viewCount)
+                .likeCount(likeCount)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
 
     public Long getWriterId() {
         return writer.getId();

--- a/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionSearchFixture.java
+++ b/src/test/java/com/benchpress200/photique/exhibition/domain/support/ExhibitionSearchFixture.java
@@ -1,0 +1,112 @@
+package com.benchpress200.photique.exhibition.domain.support;
+
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionSearch;
+import com.benchpress200.photique.user.domain.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ExhibitionSearchFixture {
+    private ExhibitionSearchFixture() {
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Long id = 1L;
+        private Long writerId = 1L;
+        private String writerNickname = "테스트유저";
+        private String writerProfileImage = "http://example.com/profile.jpg";
+        private String cardColor = "#FFFFFF";
+        private String title = "기본 전시회 제목";
+        private String description = "기본 전시회 설명";
+        private List<String> tags = List.of();
+        private Long viewCount = 0L;
+        private Long likeCount = 0L;
+        private LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+        private LocalDateTime updatedAt = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder writerId(Long writerId) {
+            this.writerId = writerId;
+            return this;
+        }
+
+        public Builder writerNickname(String writerNickname) {
+            this.writerNickname = writerNickname;
+            return this;
+        }
+
+        public Builder writerProfileImage(String writerProfileImage) {
+            this.writerProfileImage = writerProfileImage;
+            return this;
+        }
+
+        public Builder cardColor(String cardColor) {
+            this.cardColor = cardColor;
+            return this;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        public Builder viewCount(Long viewCount) {
+            this.viewCount = viewCount;
+            return this;
+        }
+
+        public Builder likeCount(Long likeCount) {
+            this.likeCount = likeCount;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder updatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+
+        public ExhibitionSearch build() {
+            User user = User.builder()
+                    .id(writerId)
+                    .nickname(writerNickname)
+                    .profileImage(writerProfileImage)
+                    .build();
+            
+            return ExhibitionSearch.of(
+                    id,
+                    user,
+                    cardColor,
+                    title,
+                    description,
+                    tags,
+                    viewCount,
+                    likeCount,
+                    createdAt,
+                    updatedAt
+            );
+        }
+    }
+}

--- a/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/exhibition/ExhibitionQueryIntegrationTest.java
@@ -7,21 +7,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
 import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionBookmarkCommandPort;
 import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionCommandPort;
+import com.benchpress200.photique.exhibition.application.command.port.out.ExhibitionLikeCommandPort;
 import com.benchpress200.photique.exhibition.domain.entity.Exhibition;
+import com.benchpress200.photique.exhibition.domain.entity.ExhibitionSearch;
 import com.benchpress200.photique.exhibition.domain.support.ExhibitionFixture;
+import com.benchpress200.photique.exhibition.domain.support.ExhibitionSearchFixture;
+import com.benchpress200.photique.exhibition.infrastructure.persistence.elasticsearch.ExhibitionSearchRepository;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @DisplayName("전시회 쿼리 API 통합 테스트")
 public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
@@ -34,6 +44,18 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private ExhibitionCommandPort exhibitionCommandPort;
+
+    @Autowired
+    private ExhibitionLikeCommandPort exhibitionLikeCommandPort;
+
+    @Autowired
+    private ExhibitionBookmarkCommandPort exhibitionBookmarkCommandPort;
+
+    @Autowired
+    private ExhibitionSearchRepository exhibitionSearchRepository;
+
+    @Autowired
+    private ElasticsearchOperations elasticsearchOperations;
 
     private User savedUser;
     private String accessToken;
@@ -52,6 +74,9 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
 
     @AfterEach
     void cleanUp() {
+        exhibitionBookmarkCommandPort.deleteAll();
+        exhibitionLikeCommandPort.deleteAll();
+        exhibitionSearchRepository.deleteAll();
         exhibitionCommandPort.deleteAll();
         userCommandPort.deleteAll();
     }
@@ -124,6 +149,192 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("전시회 검색")
+    class SearchExhibitionTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 전시회 목록을 반환하고 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            exhibitionSearchRepository.save(
+                    ExhibitionSearchFixture.builder()
+                            .id(savedExhibition.getId())
+                            .writerId(savedUser.getId())
+                            .writerNickname(savedUser.getNickname())
+                            .writerProfileImage(savedUser.getProfileImage())
+                            .build()
+            );
+
+            elasticsearchOperations.indexOps(ExhibitionSearch.class).refresh();
+
+            // when
+            ResultActions resultActions = requestSearchExhibitionAuthenticated(null, null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(30))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.isLast").value(true))
+                    .andExpect(jsonPath("$.data.hasNext").value(false))
+                    .andExpect(jsonPath("$.data.hasPrevious").value(false))
+                    .andExpect(jsonPath("$.data.exhibitions.length()").value(1))
+                    .andExpect(jsonPath("$.data.exhibitions[0].id").value(savedExhibition.getId()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].writer.id").value(savedUser.getId()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].writer.nickname").value(savedUser.getNickname()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].title").value(savedExhibition.getTitle()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].description").value(savedExhibition.getDescription()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].cardColor").value(savedExhibition.getCardColor()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].likeCount").value(savedExhibition.getLikeCount()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].viewCount").value(savedExhibition.getViewCount()))
+                    .andExpect(jsonPath("$.data.exhibitions[0].isLiked").value(false))
+                    .andExpect(jsonPath("$.data.exhibitions[0].isBookmarked").value(false));
+        }
+
+        @Test
+        @DisplayName("검색 대상이 유효하지 않으면 400을 반환한다")
+        public void whenTargetInvalid() throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            exhibitionSearchRepository.save(
+                    ExhibitionSearchFixture.builder()
+                            .id(savedExhibition.getId())
+                            .writerId(savedUser.getId())
+                            .writerNickname(savedUser.getNickname())
+                            .writerProfileImage(savedUser.getProfileImage())
+                            .build()
+            );
+
+            elasticsearchOperations.indexOps(ExhibitionSearch.class).refresh();
+
+            // when
+            ResultActions resultActions = requestSearchExhibitionAuthenticated("invalid", null, null, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.exhibition.ExhibitionQueryIntegrationTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            exhibitionSearchRepository.save(
+                    ExhibitionSearchFixture.builder()
+                            .id(savedExhibition.getId())
+                            .writerId(savedUser.getId())
+                            .writerNickname(savedUser.getNickname())
+                            .writerProfileImage(savedUser.getProfileImage())
+                            .build()
+            );
+
+            elasticsearchOperations.indexOps(ExhibitionSearch.class).refresh();
+
+            // when
+            ResultActions resultActions = requestSearchExhibitionAuthenticated(null, invalidKeyword, null, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageNegative() throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            exhibitionSearchRepository.save(
+                    ExhibitionSearchFixture.builder()
+                            .id(savedExhibition.getId())
+                            .writerId(savedUser.getId())
+                            .writerNickname(savedUser.getNickname())
+                            .writerProfileImage(savedUser.getProfileImage())
+                            .build()
+            );
+
+            elasticsearchOperations.indexOps(ExhibitionSearch.class).refresh();
+
+            // when
+            ResultActions resultActions = requestSearchExhibitionAuthenticated(null, null, -1, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("페이지 사이즈가 유효 범위를 벗어나면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.exhibition.ExhibitionQueryIntegrationTest#invalidSizes")
+        public void whenSizeOutOfRange(String invalidSize) throws Exception {
+            // given
+            Exhibition savedExhibition = exhibitionCommandPort.save(
+                    ExhibitionFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            exhibitionSearchRepository.save(
+                    ExhibitionSearchFixture.builder()
+                            .id(savedExhibition.getId())
+                            .writerId(savedUser.getId())
+                            .writerNickname(savedUser.getNickname())
+                            .writerProfileImage(savedUser.getProfileImage())
+                            .build()
+            );
+
+            elasticsearchOperations.indexOps(ExhibitionSearch.class).refresh();
+
+            // when
+            ResultActions resultActions = requestSearchExhibitionAuthenticated(
+                    null,
+                    null,
+                    null,
+                    Integer.parseInt(invalidSize)
+            );
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    private static Stream<String> invalidKeywords() {
+        return Stream.of(
+                "가",               // 최솟값 미만 (1자)
+                "a".repeat(101)     // 최댓값 초과 (101자)
+        );
+    }
+
+    private static Stream<String> invalidSizes() {
+        return Stream.of(
+                "0",    // 최솟값 미만
+                "51"    // 최댓값 초과
+        );
+    }
+
     private ResultActions requestGetExhibitionDetails(Long exhibitionId) throws Exception {
         return mockMvc.perform(
                 get(ApiPath.EXHIBITION_DATA, exhibitionId)
@@ -135,5 +346,50 @@ public class ExhibitionQueryIntegrationTest extends BaseIntegrationTest {
                 get(ApiPath.EXHIBITION_DATA, exhibitionId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
         );
+    }
+
+    private ResultActions requestSearchExhibition(
+            String target,
+            String keyword,
+            Integer page,
+            Integer size
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.EXHIBITION_ROOT);
+        if (target != null) {
+            builder = builder.param("target", target);
+        }
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+
+    private ResultActions requestSearchExhibitionAuthenticated(
+            String target,
+            String keyword,
+            Integer page,
+            Integer size
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.EXHIBITION_ROOT)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        if (target != null) {
+            builder = builder.param("target", target);
+        }
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
     }
 }


### PR DESCRIPTION
# 목적
#280 요구에 따라서 `ExhibitionQueryController.searchExhibition()` API에 대한 통합 테스트 코드를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청 유효
- 유효하지 않은 검색 대상
- 유효하지 않은 키워드
- 페이지 번호 음수
- 유효하지 않은 페이지 번호

Closes #280