### PR TITLE
test(singlework): 내 단일작품 검색 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/singlework/SingleWorkQueryIntegrationTest.java
@@ -8,12 +8,14 @@ import com.benchpress200.photique.auth.application.command.port.out.security.Aut
 import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkCommandPort;
+import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkLikeCommandPort;
 import com.benchpress200.photique.singlework.application.command.port.out.persistence.SingleWorkTagCommandPort;
 import com.benchpress200.photique.singlework.domain.entity.SingleWork;
 import com.benchpress200.photique.singlework.domain.entity.SingleWorkSearch;
 import com.benchpress200.photique.singlework.domain.support.SingleWorkFixture;
 import com.benchpress200.photique.singlework.domain.support.SingleWorkSearchFixture;
 import com.benchpress200.photique.singlework.infrastructure.persistence.elasticsearch.SingleWorkSearchRepository;
+import com.benchpress200.photique.singlework.infrastructure.persistence.jpa.SingleWorkLikeRepository;
 import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
@@ -45,6 +47,12 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
     private SingleWorkTagCommandPort singleWorkTagCommandPort;
 
     @Autowired
+    private SingleWorkLikeCommandPort singleWorkLikeCommandPort;
+
+    @Autowired
+    private SingleWorkLikeRepository singleWorkLikeRepository;
+
+    @Autowired
     private SingleWorkSearchRepository singleWorkSearchRepository;
 
     @Autowired
@@ -68,6 +76,7 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
     @AfterEach
     void cleanUp() {
         singleWorkSearchRepository.deleteAll();
+        singleWorkLikeRepository.deleteAll();
         singleWorkTagCommandPort.deleteAll();
         singleWorkCommandPort.deleteAll();
         userCommandPort.deleteAll();
@@ -172,12 +181,8 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
         @Test
         @DisplayName("검색 대상이 유효하지 않으면 400을 반환한다")
         public void whenTargetInvalid() throws Exception {
-            // given
-            String invalidTarget = "invalid";
-            String keyword = "단일";
-
             // when
-            ResultActions resultActions = requestSearchSingleWorkAuthenticated(invalidTarget, keyword, null, null);
+            ResultActions resultActions = requestSearchSingleWorkAuthenticated("INVALID", "단일", null, null);
 
             // then
             resultActions.andExpect(status().isBadRequest());
@@ -186,12 +191,129 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
         @Test
         @DisplayName("키워드 길이가 2 미만이면 400을 반환한다")
         public void whenKeywordTooShort() throws Exception {
+            // when
+            ResultActions resultActions = requestSearchSingleWorkAuthenticated("work", "가", null, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageNegative() throws Exception {
+            // when
+            ResultActions resultActions = requestSearchSingleWorkAuthenticated("work", "단일", -1, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 사이즈가 유효 범위를 벗어나면 400을 반환한다")
+        public void whenSizeOutOfRange() throws Exception {
+            // when
+            ResultActions resultActions = requestSearchSingleWorkAuthenticated("work", "단일", null, 0);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("내 단일작품 검색")
+    class SearchMySingleWorkTest {
+
+        @Test
+        @DisplayName("요청이 유효하면 내 단일작품 목록을 반환하고 200을 반환한다")
+        public void whenRequestValid() throws Exception {
             // given
-            String target = "work";
+            SingleWork savedSingleWork = singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated(null, null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(30))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.isFirst").value(true))
+                    .andExpect(jsonPath("$.data.isLast").value(true))
+                    .andExpect(jsonPath("$.data.hasNext").value(false))
+                    .andExpect(jsonPath("$.data.hasPrevious").value(false))
+                    .andExpect(jsonPath("$.data.singleWorks.length()").value(1))
+                    .andExpect(jsonPath("$.data.singleWorks[0].id").value(savedSingleWork.getId()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].writer.id").value(savedUser.getId()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].writer.nickname").value(savedUser.getNickname()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].writer.profileImage").value(savedUser.getProfileImage()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].image").value(savedSingleWork.getImage()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].likeCount").value(savedSingleWork.getLikeCount()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].viewCount").value(savedSingleWork.getViewCount()))
+                    .andExpect(jsonPath("$.data.singleWorks[0].isLiked").value(false));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // when
+            ResultActions resultActions = requestSearchMySingleWork(null, null, null, null);
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("키워드가 제목에 매칭되면 해당 단일작품만 반환한다")
+        public void whenKeywordMatchesTitle() throws Exception {
+            // given
+            singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated("기본", null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.singleWorks.length()").value(1));
+        }
+
+        @Test
+        @DisplayName("키워드가 제목에 매칭되지 않으면 빈 목록을 반환한다")
+        public void whenKeywordNotMatches() throws Exception {
+            // given
+            singleWorkCommandPort.save(
+                    SingleWorkFixture.builder()
+                            .writer(savedUser)
+                            .build()
+            );
+
+            // when
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated("없는키워드", null, null, null);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.singleWorks.length()").value(0));
+        }
+
+        @Test
+        @DisplayName("키워드 길이가 2 미만이면 400을 반환한다")
+        public void whenKeywordTooShort() throws Exception {
+            // given
             String invalidKeyword = "가";
 
             // when
-            ResultActions resultActions = requestSearchSingleWorkAuthenticated(target, invalidKeyword, null, null);
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated(invalidKeyword, null, null, null);
 
             // then
             resultActions.andExpect(status().isBadRequest());
@@ -201,13 +323,10 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
         @DisplayName("페이지 번호가 음수이면 400을 반환한다")
         public void whenPageNegative() throws Exception {
             // given
-            String target = "work";
-            String keyword = "단일";
             int invalidPage = -1;
 
             // when
-            ResultActions resultActions = requestSearchSingleWorkAuthenticated(target, keyword, invalidPage,
-                    null);
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated(null, invalidPage, null, null);
 
             // then
             resultActions.andExpect(status().isBadRequest());
@@ -217,12 +336,23 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
         @DisplayName("페이지 사이즈가 유효 범위를 벗어나면 400을 반환한다")
         public void whenSizeOutOfRange() throws Exception {
             // given
-            String target = "work";
-            String keyword = "단일";
-            int size = 0;
+            int invalidSize = 0;
 
             // when
-            ResultActions resultActions = requestSearchSingleWorkAuthenticated(target, keyword, null, size);
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated(null, null, invalidSize, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("정렬 기준이 유효하지 않으면 400을 반환한다")
+        public void whenSortInvalid() throws Exception {
+            // given
+            String invalidSort = "invalid";
+
+            // when
+            ResultActions resultActions = requestSearchMySingleWorkAuthenticated(null, null, null, invalidSort);
 
             // then
             resultActions.andExpect(status().isBadRequest());
@@ -275,6 +405,51 @@ public class SingleWorkQueryIntegrationTest extends BaseIntegrationTest {
         }
         if (size != null) {
             builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+
+    private ResultActions requestSearchMySingleWork(
+            String keyword,
+            Integer page,
+            Integer size,
+            String sort
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_MY_DATA);
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        if (sort != null) {
+            builder = builder.param("sort", sort);
+        }
+        return mockMvc.perform(builder);
+    }
+
+    private ResultActions requestSearchMySingleWorkAuthenticated(
+            String keyword,
+            Integer page,
+            Integer size,
+            String sort
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.SINGLEWORK_MY_DATA)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        if (sort != null) {
+            builder = builder.param("sort", sort);
         }
         return mockMvc.perform(builder);
     }


### PR DESCRIPTION
# 목적
#261 요구에 따라서 SingleWorkQueryIntegrationTest의 SearchMySingleWorkTest에 대한 통합 테스트를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청이 유효한 경우
- 인증되지 않은 경우
- 키워드가 제목과 일치하는 경우
- 키워드가 일치하지 않는 경우
- 키워드가 너무 짧은 경우
- 페이지 번호가 음수인 경우
- 페이지 사이즈가 범위를 벗어난 경우
- 정렬 기준이 유효하지 않은 경우

Closes #261