### PR TITLE
test(user): 유저 정보 수정 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/user/UserCommandIntegrationTest.java
@@ -4,7 +4,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.benchpress200.photique.auth.application.command.port.out.persistence.AuthMailCodeCommandPort;
+import com.benchpress200.photique.auth.application.command.port.out.security.AuthenticationTokenManagerPort;
 import com.benchpress200.photique.auth.domain.entity.AuthMailCode;
+import com.benchpress200.photique.auth.domain.vo.AuthenticationTokens;
 import com.benchpress200.photique.common.api.constant.ApiPath;
 import com.benchpress200.photique.common.api.constant.MultipartKey;
 import com.benchpress200.photique.integration.auth.support.fixture.AuthMailCodeFixture;
@@ -12,6 +14,7 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.support.fixture.MultipartFileFixture;
 import com.benchpress200.photique.support.fixture.MultipartJsonFixture;
 import com.benchpress200.photique.user.api.command.support.fixture.ResisterRequestFixture;
+import com.benchpress200.photique.user.api.command.support.fixture.UserDetailsUpdateRequestFixture;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.application.query.port.out.persistence.UserQueryPort;
 import com.benchpress200.photique.user.domain.entity.User;
@@ -20,12 +23,15 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.ResultActions;
@@ -42,6 +48,12 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     private UserCommandPort userCommandPort;
+
+    @Autowired
+    private AuthenticationTokenManagerPort authenticationTokenManagerPort;
+
+    private User savedUser;
+    private String accessToken;
 
     @AfterEach
     void cleanUp() {
@@ -307,6 +319,166 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("유저 정보 수정")
+    class UpdateUserDetailsTest {
+        @BeforeEach
+        void setUp() {
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            AuthenticationTokens tokens = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            );
+            accessToken = tokens.getAccessToken();
+        }
+
+        @Test
+        @DisplayName("요청이 유효하면 유저 정보를 수정하고 204를 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(savedUser.getId(), userPart, null);
+            Optional<User> updatedUser = userQueryPort.findByIdAndDeletedAtIsNull(savedUser.getId());
+
+            // then
+            resultActions.andExpect(status().isNoContent());
+            Assertions.assertThat(updatedUser)
+                    .isPresent()
+                    .get()
+                    .satisfies(u -> {
+                        Assertions.assertThat(u.getNickname()).isEqualTo(request.getNickname());
+                        Assertions.assertThat(u.getIntroduction()).isEqualTo(request.getIntroduction());
+                    });
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetails(savedUser.getId(), userPart, null);
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("다른 유저의 userId로 수정을 요청하면 403을 반환한다")
+        public void whenAnotherUserForbidden() throws Exception {
+            // given
+            User otherUser = userCommandPort.save(UserFixture.builder()
+                    .email("other@example.com")
+                    .nickname("다른유저")
+                    .build());
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(otherUser.getId(), userPart, null);
+
+            // then
+            resultActions.andExpect(status().isForbidden());
+        }
+
+        @ParameterizedTest
+        @DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.user.UserCommandIntegrationTest#invalidUpdateNicknames")
+        public void whenNicknameInvalid(String invalidNickname) throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
+                    .nickname(invalidNickname)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(savedUser.getId(), userPart, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("한 줄 소개가 50자를 초과하면 400을 반환한다")
+        public void whenIntroductionTooLong() throws Exception {
+            // given
+            String invalidIntroduction = "가".repeat(51);
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder()
+                    .introduction(invalidIntroduction)
+                    .build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(savedUser.getId(), userPart, null);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("프로필 사진이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.user.UserCommandIntegrationTest#invalidUpdateProfileImages")
+        public void whenProfileImageInvalid(MockMultipartFile invalidProfileImage) throws Exception {
+            // given
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(savedUser.getId(), userPart, invalidProfileImage);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않으면 404를 반환한다")
+        public void whenUserNotFound() throws Exception {
+            // given
+            userCommandPort.deleteAll();
+            UserDetailsUpdateRequestFixture request = UserDetailsUpdateRequestFixture.builder().build();
+            MockMultipartFile userPart = MultipartJsonFixture.builder()
+                    .key(MultipartKey.USER)
+                    .object(request)
+                    .objectMapper(objectMapper)
+                    .build();
+
+            // when
+            ResultActions resultActions = requestUpdateUserDetailsAuthenticated(savedUser.getId(), userPart, null);
+
+            // then
+            resultActions.andExpect(status().isNotFound());
+        }
+    }
+
     private static Stream<MockMultipartFile> invalidProfileImages() {
         MockMultipartFile emptyImage = MultipartFileFixture.builder()
                 .key(MultipartKey.PROFILE_IMAGE)
@@ -350,6 +522,41 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
         );
     }
 
+    private static Stream<String> invalidUpdateNicknames() {
+        return Stream.of(
+                "nick name",        // 공백 포함
+                "a".repeat(12)      // 12자 (최댓값 초과)
+        );
+    }
+
+    private static Stream<MockMultipartFile> invalidUpdateProfileImages() {
+        MockMultipartFile bigImage = MultipartFileFixture.builder()
+                .key(MultipartKey.PROFILE_IMAGE)
+                .fileName("profile.jpg")
+                .contentType(MediaType.IMAGE_JPEG_VALUE)
+                .content(new byte[5 * 1024 * 1024 + 1])
+                .build();
+
+        MockMultipartFile noNameImage = MultipartFileFixture.builder()
+                .key(MultipartKey.PROFILE_IMAGE)
+                .contentType(MediaType.IMAGE_JPEG_VALUE)
+                .content(new byte[1])
+                .build();
+
+        MockMultipartFile gifImage = MultipartFileFixture.builder()
+                .key(MultipartKey.PROFILE_IMAGE)
+                .fileName("profile.gif")
+                .contentType(MediaType.IMAGE_GIF_VALUE)
+                .content(new byte[1])
+                .build();
+
+        return Stream.of(
+                bigImage,       // 5MB 초과
+                noNameImage,    // 파일명 없음
+                gifImage        // 허용되지 않는 확장자
+        );
+    }
+
     private static Stream<String> invalidPasswords() {
         return Stream.of(
                 null,           // @NotNull 위반
@@ -380,5 +587,39 @@ public class UserCommandIntegrationTest extends BaseIntegrationTest {
         MockHttpServletRequestBuilder httpBuilder = multipartBuilder.contentType(MediaType.MULTIPART_FORM_DATA);
 
         return mockMvc.perform(httpBuilder);
+    }
+
+    private ResultActions requestUpdateUserDetails(
+            Long userId,
+            MockMultipartFile userPart,
+            MockMultipartFile profileImagePart
+    ) throws Exception {
+        MockMultipartHttpServletRequestBuilder multipartBuilder = multipart(HttpMethod.PATCH, ApiPath.USER_DATA, userId)
+                .file(userPart);
+
+        if (profileImagePart != null) {
+            multipartBuilder = multipartBuilder.file(profileImagePart);
+        }
+
+        return mockMvc.perform(multipartBuilder.contentType(MediaType.MULTIPART_FORM_DATA));
+    }
+
+    private ResultActions requestUpdateUserDetailsAuthenticated(
+            Long userId,
+            MockMultipartFile userPart,
+            MockMultipartFile profileImagePart
+    ) throws Exception {
+        MockMultipartHttpServletRequestBuilder multipartBuilder = multipart(HttpMethod.PATCH, ApiPath.USER_DATA, userId)
+                .file(userPart);
+
+        if (profileImagePart != null) {
+            multipartBuilder = multipartBuilder.file(profileImagePart);
+        }
+
+        return mockMvc.perform(
+                multipartBuilder
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+        );
     }
 }


### PR DESCRIPTION
# 목적
#237 요구에 따라서 UserCommandIntegrationTest의 UpdateUserDetailsTest에 대한 통합 테스트를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청이 유효한 경우
- 인증되지 않은 경우
- 다른 유저의 userId로 수정을 요청하는 경우
- 닉네임이 유효하지 않은 경우
- 한 줄 소개가 50자를 초과하는 경우
- 프로필 사진이 유효하지 않은 경우
- 유저가 존재하지 않는 경우

Closes #237