### PR TITLE
test(user): 유저 닉네임 중복검사 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/user/UserQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/user/UserQueryIntegrationTest.java
@@ -10,13 +10,17 @@ import com.benchpress200.photique.support.base.BaseIntegrationTest;
 import com.benchpress200.photique.user.application.command.port.out.persistence.UserCommandPort;
 import com.benchpress200.photique.user.domain.entity.User;
 import com.benchpress200.photique.user.domain.support.UserFixture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 @DisplayName("유저 쿼리 API 통합 테스트")
 public class UserQueryIntegrationTest extends BaseIntegrationTest {
@@ -99,6 +103,62 @@ public class UserQueryIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("닉네임 중복검사")
+    class ValidateNicknameTest {
+        @Test
+        @DisplayName("닉네임이 중복되지 않으면 isDuplicated가 false이고 200을 반환한다")
+        public void whenNicknameNotDuplicated() throws Exception {
+            // given
+            String nickname = "새닉네임";
+            userCommandPort.save(UserFixture.builder().build());
+
+            // when
+            ResultActions resultActions = requestValidateNickname(nickname);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.isDuplicated").value(false));
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 isDuplicated가 true이고 200을 반환한다")
+        public void whenNicknameDuplicated() throws Exception {
+            // given
+            User user = userCommandPort.save(UserFixture.builder().build());
+            String nickname = user.getNickname();
+
+            // when
+            ResultActions resultActions = requestValidateNickname(nickname);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.isDuplicated").value(true));
+        }
+
+        @ParameterizedTest
+        @DisplayName("닉네임이 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.user.UserQueryIntegrationTest#invalidNicknames")
+        public void whenNicknameInvalid(String invalidNickname) throws Exception {
+            // when
+            ResultActions resultActions = requestValidateNickname(invalidNickname);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    private static Stream<String> invalidNicknames() {
+        return Stream.of(
+                null,
+                "",
+                "공백 포함",
+                "a".repeat(12)
+        );
+    }
+
     private ResultActions requestGetUserDetails(Long userId) throws Exception {
         return mockMvc.perform(get(ApiPath.USER_DATA, userId));
     }
@@ -108,5 +168,13 @@ public class UserQueryIntegrationTest extends BaseIntegrationTest {
                 get(ApiPath.USER_DATA, userId)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
         );
+    }
+
+    private ResultActions requestValidateNickname(String nickname) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.USER_NICKNAME_EXISTS);
+        if (nickname != null) {
+            builder = builder.param("nickname", nickname);
+        }
+        return mockMvc.perform(builder);
     }
 }


### PR DESCRIPTION
# 목적
#245 요구에 따라서 UserQueryController.validateNickname() API에 대한 통합 테스트를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 닉네임이 중복되지 않는 경우
- 닉네임이 중복된 경우
- 닉네임이 유효하지 않은 경우

Closes #245