### PR TITLE
test(user): 유저 검색 API 통합 테스트 코드 작성

### DIFF
--- a/src/test/java/com/benchpress200/photique/integration/user/UserQueryIntegrationTest.java
+++ b/src/test/java/com/benchpress200/photique/integration/user/UserQueryIntegrationTest.java
@@ -216,6 +216,150 @@ public class UserQueryIntegrationTest extends BaseIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("유저 검색")
+    class SearchUserTest {
+        @Test
+        @DisplayName("요청이 유효하면 검색 결과를 반환하고 200을 반환한다")
+        public void whenRequestValid() throws Exception {
+            // given
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            User targetUser = userCommandPort.save(UserFixture.builder()
+                    .email("target@example.com")
+                    .nickname("타겟유저")
+                    .build());
+            accessToken = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            ).getAccessToken();
+
+            int page = 0;
+            int size = 30;
+            String keyword = "타겟";
+
+            // when
+            ResultActions resultActions = requestSearchUser(keyword, page, size);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.users[0].nickname").value(targetUser.getNickname()));
+        }
+
+        @Test
+        @DisplayName("검색 결과가 없으면 빈 목록을 반환하고 200을 반환한다")
+        public void whenSearchResultEmpty() throws Exception {
+            // given
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            accessToken = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            ).getAccessToken();
+
+            int page = 0;
+            int size = 30;
+            String keyword = "없는키워드";
+
+            // when
+            ResultActions resultActions = requestSearchUser(keyword, page, size);
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("인증 토큰이 없으면 401을 반환한다")
+        public void whenNotAuthenticated() throws Exception {
+            // given
+            String keyword = "테스트";
+
+            // when
+            ResultActions resultActions = requestSearchUserUnauthenticated(keyword);
+
+            // then
+            resultActions.andExpect(status().isUnauthorized());
+        }
+
+        @ParameterizedTest
+        @DisplayName("검색 키워드가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.user.UserQueryIntegrationTest#invalidKeywords")
+        public void whenKeywordInvalid(String invalidKeyword) throws Exception {
+            // given
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            accessToken = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            ).getAccessToken();
+
+            int page = 0;
+            int size = 30;
+
+            // when
+            ResultActions resultActions = requestSearchUser(invalidKeyword, page, size);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("페이지 번호가 음수이면 400을 반환한다")
+        public void whenPageInvalid() throws Exception {
+            // given
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            accessToken = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            ).getAccessToken();
+
+            String keyword = "테스트";
+            int invalidPage = -1;
+            int size = 30;
+
+            // when
+            ResultActions resultActions = requestSearchUser(keyword, invalidPage, size);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @DisplayName("페이지 크기가 유효하지 않으면 400을 반환한다")
+        @MethodSource("com.benchpress200.photique.integration.user.UserQueryIntegrationTest#invalidSizes")
+        public void whenSizeInvalid(Integer invalidSize) throws Exception {
+            // given
+            savedUser = userCommandPort.save(UserFixture.builder().build());
+            accessToken = authenticationTokenManagerPort.issueTokens(
+                    savedUser.getId(),
+                    savedUser.getRole().name()
+            ).getAccessToken();
+
+            String keyword = "테스트";
+            int page = 0;
+
+            // when
+            ResultActions resultActions = requestSearchUser(keyword, page, invalidSize);
+
+            // then
+            resultActions.andExpect(status().isBadRequest());
+        }
+    }
+
+    private static Stream<String> invalidKeywords() {
+        return Stream.of(
+                null,
+                "",
+                "공백 포함",
+                "a".repeat(12)
+        );
+    }
+
+    private static Stream<Integer> invalidSizes() {
+        return Stream.of(0, 51);
+    }
+
     private ResultActions requestGetUserDetails(Long userId) throws Exception {
         return mockMvc.perform(get(ApiPath.USER_DATA, userId));
     }
@@ -243,6 +387,32 @@ public class UserQueryIntegrationTest extends BaseIntegrationTest {
         return mockMvc.perform(
                 get(ApiPath.USER_MY_DATA)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        );
+    }
+
+    private ResultActions requestSearchUser(
+            String keyword,
+            Integer page,
+            Integer size
+    ) throws Exception {
+        MockHttpServletRequestBuilder builder = get(ApiPath.USER_ROOT)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        if (keyword != null) {
+            builder = builder.param("keyword", keyword);
+        }
+        if (page != null) {
+            builder = builder.param("page", String.valueOf(page));
+        }
+        if (size != null) {
+            builder = builder.param("size", String.valueOf(size));
+        }
+        return mockMvc.perform(builder);
+    }
+
+    private ResultActions requestSearchUserUnauthenticated(String keyword) throws Exception {
+        return mockMvc.perform(
+                get(ApiPath.USER_ROOT)
+                        .param("keyword", keyword)
         );
     }
 }


### PR DESCRIPTION
# 목적
#248 요구에 따라서 UserQueryController.searchUser() API에 대한 통합 테스트를 작성했습니다.

# 작업 내용
아래 케이스에 대한 테스트 코드를 작성했습니다.
- 요청이 유효한 경우
- 검색 결과가 없는 경우
- 인증 토큰이 없는 경우
- 검색 키워드가 유효하지 않은 경우
- 페이지 번호가 유효하지 않은 경우
- 페이지 크기가 유효하지 않은 경우

Closes #248