### PR TITLE
test: 테스트 커버리지 측정을 위한 JaCoCo 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.0'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'com.benchpress200'
@@ -125,4 +126,27 @@ tasks.register('copyTestSecret', Copy) {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// JaCoCo 설정 추가
+jacoco {
+    toolVersion = "0.8.14"
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+jacocoTestReport {
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+        xml.outputLocation = layout.buildDirectory.file('jacoco/result.xml')
+    }
 }


### PR DESCRIPTION
# 목적
#431 요구에 따라서 JaCoCo를 추가했습니다.

# 작업 내용
JaCoCo 플러그인을 추가하고 테스트 커버리지 결과 출력을 확인했습니다.


Closes #431 