### PR TITLE
test: 테스트 커버리지 측정에서 Q 클래스 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,4 +149,14 @@ jacocoTestReport {
         html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
         xml.outputLocation = layout.buildDirectory.file('jacoco/result.xml')
     }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: [
+                            '**/Q*'
+                    ])
+                })
+        )
+    }
 }


### PR DESCRIPTION
# 작업 내용
QueryDSL에 의해 생성된 `**/Q*` 패턴의 클래스는 커버리지 측정에서 제외하도록 설정했습니다.